### PR TITLE
Fix gedcom_path fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from backend.main import create_app
 from backend.models import Base
 import backend.db  # so we can patch SessionLocal + engine
 import os
+from pathlib import Path
 
 
 @pytest.fixture(scope="session")
@@ -44,7 +45,7 @@ def db_session():
 @pytest.fixture
 def gedcom_path():
     # adjust if your test file lives somewhere else
-    return os.path.abspath("/Users/kingal/mapem/tests/data/test_family_events.ged")
+    return Path(__file__).parent / "data/test_family_events.ged"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- fix `gedcom_path` to build paths relative to the file

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: NameError in LocationService)*

------
https://chatgpt.com/codex/tasks/task_e_683f59eb0e34832ab22decadb414f64c

## Summary by Sourcery

Tests:
- Use Path(__file__).parent to compute the gedcom_path fixture relative to the conftest file rather than a fixed path