### PR TITLE
Fix extraneous character in router file

### DIFF
--- a/frontend/src/app/router.jsx
+++ b/frontend/src/app/router.jsx
@@ -23,7 +23,7 @@ export default function Router() {
           <Route path="people" element={<PeoplePage />} />
           <Route path="analytics" element={<Analytics />} />
           <Route path="upload" element={<UploadPage />} />
-]          <Route path="*" element={<div className="p-10 text-white">404: Page Not Found</div>} />
+          <Route path="*" element={<div className="p-10 text-white">404: Page Not Found</div>} />
         </Route>
       </Routes>
     </Suspense>


### PR DESCRIPTION
## Summary
- clean up Routes block in frontend router

## Testing
- `npm run lint`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_683f59e2e954832a8cb635334768de2b