### PR TITLE
Fix logger config on modules

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,9 +11,8 @@ from backend.db import get_engine, SessionLocal
 from backend.routes.heatmap import warmup_heatmap
 
 # ─── Logger Setup ───────────────────────────────────────────────
-logger = logging.getLogger("mapem")
-logging.getLogger().setLevel(logging.DEBUG)
-logging.getLogger().propagate = True
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 formatter = logging.Formatter("%(asctime)s — %(levelname)s — %(message)s")
 

--- a/backend/models/event.py
+++ b/backend/models/event.py
@@ -7,9 +7,8 @@ from .base import Base, ReprMixin
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
 
-logger = logging.getLogger("mapem.models.Event")
-logging.getLogger().setLevel(logging.DEBUG)
-logging.getLogger().propagate = True
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 # ─── Association Table: Event ↔ Individual ─────────────
 event_participants = Table(

--- a/backend/routes/events.py
+++ b/backend/routes/events.py
@@ -8,9 +8,8 @@ from backend.models import Event, TreeVersion
 from backend.utils.debug_routes import debug_route
 
 event_routes = Blueprint("events", __name__, url_prefix="/api/events")
-logger = logging.getLogger("mapem")
-logging.getLogger().setLevel(logging.DEBUG)
-logging.getLogger().propagate = True
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 @event_routes.route("/", methods=["GET"], strict_slashes=False)
 @cross_origin()


### PR DESCRIPTION
## Summary
- configure loggers only on their modules
- drop root logger modifications

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_683f59f81b70832a9dac05772f53bf26