### PR TITLE
Fix geocode task API usage

### DIFF
--- a/backend/services/location_service.py
+++ b/backend/services/location_service.py
@@ -224,7 +224,7 @@ class LocationService:
             source="none",
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
-    logger.debug(
-        "✅ LocationService loaded with resolve_location=%s",
-        hasattr(LocationService, "resolve_location"),
-    )
+logger.debug(
+    "✅ LocationService loaded with resolve_location=%s",
+    hasattr(LocationService, "resolve_location"),
+)

--- a/backend/tasks/geocode_tasks.py
+++ b/backend/tasks/geocode_tasks.py
@@ -40,19 +40,19 @@ def geocode_location_task(self, location_id: int):
                 return
 
             # 🔍 Attempt resolution
-            result = geocoder.resolve(loc.raw_name)
-            if not result:
+            result = geocoder.get_or_create_location(None, loc.raw_name)
+            if result is None:
                 raise ValueError(f"Geocoder returned no data for '{loc.raw_name}'")
 
             # ✅ Apply fields
-            loc.latitude         = result["latitude"]
-            loc.longitude        = result["longitude"]
-            loc.normalized_name  = result["normalized_name"]
-            loc.confidence_score = result["confidence_score"]
-            loc.status           = result["status"]
-            loc.source           = result["source"]
-            loc.geocoded_at      = result.get("geocoded_at")
-            loc.geocoded_by      = result.get("geocoded_by")
+            loc.latitude         = result.latitude
+            loc.longitude        = result.longitude
+            loc.normalized_name  = result.normalized_name
+            loc.confidence_score = result.confidence_score
+            loc.status           = result.status
+            loc.source           = result.source
+            loc.geocoded_at      = getattr(result, "geocoded_at", None)
+            loc.geocoded_by      = getattr(result, "geocoded_by", None)
 
             session.commit()
             logger.info(f"[GeocodeTask] ✅ id={location_id} -> ({loc.latitude}, {loc.longitude})")


### PR DESCRIPTION
## Summary
- use `get_or_create_location` in celery geocoding task
- update field assignments to use attribute access
- move debug log outside `LocationService` class

## Testing
- `pytest -q` *(fails: connection to PostgreSQL refused)*

------
https://chatgpt.com/codex/tasks/task_e_683f62deee08832a9658fcd5d3a69b35

## Summary by Sourcery

Refactor the geocoding task to use the new get_or_create_location API, switch field assignments to object attributes, and move the LocationService debug log outside its class definition

Enhancements:
- Use geocoder.get_or_create_location instead of geocoder.resolve in the Celery geocode task
- Assign location fields via object attributes and getattr for optional values instead of dict lookups
- Move the LocationService debug logging statement out of the class body to module scope