### PR TITLE
Centralize LocationOut model

### DIFF
--- a/backend/services/geocode.py
+++ b/backend/services/geocode.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime
 from urllib.parse import urlencode
 from typing import Optional, Dict, Any
-from pydantic import BaseModel
+from backend.models.location_models import LocationOut
 
 from backend import models
 from backend.utils.helpers import normalize_location, calculate_name_similarity
@@ -15,15 +15,6 @@ logger = logging.getLogger("backend.services.geocode")
 logger.setLevel(logging.DEBUG)
 
 # ─── Return model (Pydantic, exportable) ───────────
-class LocationOut(BaseModel):
-    raw_name: str
-    normalized_name: str
-    latitude: Optional[float] = None
-    longitude: Optional[float] = None
-    confidence_score: float = 0.0
-    confidence_label: str = ""
-    status: str = ""
-    source: str = ""
 
 def classify_location_failure(raw_name):
     generic = {"mississippi", "usa", "tennessee", "louisiana", "unknown"}
@@ -163,9 +154,9 @@ class Geocode:
                     latitude=override["lat"],
                     longitude=override["lng"],
                     confidence_score=1.0,
-                    confidence_label="manual",
                     status="manual",
-                    source="manual"
+                    source="manual",
+                    timestamp=datetime.now().isoformat(),
                 )
             return None
 
@@ -181,9 +172,9 @@ class Geocode:
                     latitude=hp["lat"],
                     longitude=hp["lng"],
                     confidence_score=1.0,
-                    confidence_label="historical",
                     status="historical",
-                    source="historical"
+                    source="historical",
+                    timestamp=datetime.now().isoformat(),
                 )
             return None
 
@@ -203,9 +194,9 @@ class Geocode:
                     latitude=lat,
                     longitude=lng,
                     confidence_score=float(conf or 0.0),
-                    confidence_label="cache",
                     status="ok",
-                    source="cache"
+                    source="cache",
+                    timestamp=datetime.now().isoformat(),
                 )
             logger.warning(f"⚠️ Cache miss or incomplete for '{raw_name}'")
             return None
@@ -223,9 +214,9 @@ class Geocode:
                         latitude=loc.latitude,
                         longitude=loc.longitude,
                         confidence_score=float(loc.confidence_score or 0.0),
-                        confidence_label="db",
                         status="ok",
-                        source="db"
+                        source="db",
+                        timestamp=datetime.now().isoformat(),
                     )
 
         # External geocode (Google first, then Nominatim fallback)
@@ -265,9 +256,9 @@ class Geocode:
             latitude=lat,
             longitude=lng,
             confidence_score=float(conf or 0.0),
-            confidence_label="api",
             status="ok",
-            source=source
+            source=source,
+            timestamp=datetime.now().isoformat(),
         )
 
 # Export the return model for your tests and routes

--- a/backend/services/location_service.py
+++ b/backend/services/location_service.py
@@ -224,7 +224,8 @@ class LocationService:
             source="none",
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
-    logger.debug(
-        "✅ LocationService loaded with resolve_location=%s",
-        hasattr(LocationService, "resolve_location"),
-    )
+
+logger.debug(
+    "✅ LocationService loaded with resolve_location=%s",
+    hasattr(LocationService, "resolve_location"),
+)

--- a/tests/services/test_geocode.py
+++ b/tests/services/test_geocode.py
@@ -1,5 +1,6 @@
 import pytest
-from backend.services.geocode import Geocode, LocationOut
+from backend.services.geocode import Geocode
+from backend.models.location_models import LocationOut
 
 @pytest.fixture
 def geocoder():

--- a/tests/services/test_location_service.py
+++ b/tests/services/test_location_service.py
@@ -6,7 +6,7 @@ import os  # ← needed by test_override_applies_before_geocoder
 
 
 from backend.services.location_service import LocationService
-from backend.services.location_processor import LocationOut
+from backend.models.location_models import LocationOut
 
 
 def fake_timestamp() -> str:
@@ -61,23 +61,27 @@ def service(monkeypatch) -> LocationService:
             Anything else returns None so the code drops to the fallback path.
             """
             if normalized_name == "realcity_rc":
-                return {
-                    "normalized_name": "realcity_rc",
-                    "latitude": 5.5,
-                    "longitude": 6.6,
-                    "confidence_score": 0.9,
-                    "status": "ok",
-                    "source": "external",
-                }
+                return LocationOut(
+                    raw_name="RealCity, RC",
+                    normalized_name="realcity_rc",
+                    latitude=5.5,
+                    longitude=6.6,
+                    confidence_score=0.9,
+                    status="ok",
+                    source="external",
+                    timestamp=fake_timestamp(),
+                )
             if normalized_name == "mississippi":
-                return {
-                    "normalized_name": "mississippi",
-                    "latitude": 0,
-                    "longitude": 0,
-                    "confidence_score": 0.5,
-                    "status": "vague_state_pre1890",
-                    "source": "vague",
-                }
+                return LocationOut(
+                    raw_name="Mississippi",
+                    normalized_name="mississippi",
+                    latitude=0,
+                    longitude=0,
+                    confidence_score=0.5,
+                    status="vague_state_pre1890",
+                    source="vague",
+                    timestamp=fake_timestamp(),
+                )
             return None
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- keep a single LocationOut definition in `backend/models`
- import the shared model in `backend/services/geocode`
- adapt Geocode to create LocationOuts with timestamps
- update service tests to use the common model
- fix `LocationService` module init logging

## Testing
- `pytest tests/services/test_geocode.py -q`
- `pytest tests/services/test_location_service.py -q`
- `pytest -q` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_683f62e44ef8832a80571b337d96b060

## Summary by Sourcery

Centralize the LocationOut model into a single definition, update geocoding and location service to include timestamps, streamline imports in tests and services, and correct the LocationService initialization logging.

Bug Fixes:
- Fix the placement of the debug logging statement in the LocationService module initialization

Enhancements:
- Consolidate the LocationOut schema in backend/models/location_models and remove inline definitions
- Populate a timestamp on all LocationOut instances created by Geocode and LocationService
- Refactor service and test modules to import LocationOut from the shared model

Tests:
- Update test_geocode and test_location_service to reference the centralized LocationOut model