### PR TITLE
Fix geocode task to use new location service

### DIFF
--- a/backend/services/location_service.py
+++ b/backend/services/location_service.py
@@ -224,7 +224,7 @@ class LocationService:
             source="none",
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
-    logger.debug(
-        "✅ LocationService loaded with resolve_location=%s",
-        hasattr(LocationService, "resolve_location"),
-    )
+logger.debug(
+    "✅ LocationService loaded with resolve_location=%s",
+    hasattr(LocationService, "resolve_location"),
+)

--- a/backend/tasks/geocode_tasks.py
+++ b/backend/tasks/geocode_tasks.py
@@ -40,19 +40,22 @@ def geocode_location_task(self, location_id: int):
                 return
 
             # 🔍 Attempt resolution
-            result = geocoder.resolve(loc.raw_name)
-            if not result:
-                raise ValueError(f"Geocoder returned no data for '{loc.raw_name}'")
+            result = geocoder.get_or_create_location(None, loc.raw_name)
+            if result is None:
+                logger.warning(
+                    f"[GeocodeTask] Geocoder returned no data for '{loc.raw_name}'"
+                )
+                return
 
             # ✅ Apply fields
-            loc.latitude         = result["latitude"]
-            loc.longitude        = result["longitude"]
-            loc.normalized_name  = result["normalized_name"]
-            loc.confidence_score = result["confidence_score"]
-            loc.status           = result["status"]
-            loc.source           = result["source"]
-            loc.geocoded_at      = result.get("geocoded_at")
-            loc.geocoded_by      = result.get("geocoded_by")
+            loc.latitude = result.latitude
+            loc.longitude = result.longitude
+            loc.normalized_name = result.normalized_name
+            loc.confidence_score = result.confidence_score
+            loc.status = result.status
+            loc.source = result.source
+            loc.geocoded_at = getattr(result, "geocoded_at", None)
+            loc.geocoded_by = getattr(result, "geocoded_by", None)
 
             session.commit()
             logger.info(f"[GeocodeTask] ✅ id={location_id} -> ({loc.latitude}, {loc.longitude})")


### PR DESCRIPTION
## Summary
- update geocode task to use `get_or_create_location`
- guard against None responses
- adjust location service logger placement

## Testing
- `pytest -q` *(fails: connection refused to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_683f63e5720c832abc598f9d7880b956

## Summary by Sourcery

Update the geocode task to integrate with the new location service API and improve its error handling.

Enhancements:
- Replace geocoder.resolve with get_or_create_location in the geocode task
- Change result data access from dict keys to object attributes
- Handle None responses from the location service by logging a warning and exiting early
- Move LocationService logger.debug call out of the class definition to module level