### PR TITLE
Fix normalize_location import in log utils

### DIFF
--- a/backend/utils/log_utils.py
+++ b/backend/utils/log_utils.py
@@ -9,7 +9,7 @@
 # logging.py
 from backend.models import UserAction
 from datetime import datetime
-from backend.services.location_processor import normalize_location
+from backend.utils.helpers import normalize_location
 
 
 def log_action(session, user_id, action_type, context, decision, tree_id=None):


### PR DESCRIPTION
## Summary
- import `normalize_location` from `backend.utils.helpers` in `log_utils`

## Testing
- `pytest -q` *(fails: NameError: name 'LocationService' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_683f63e9d844832a80320c1cf72a8e34

## Summary by Sourcery

Bug Fixes:
- Correct the import path for normalize_location in log_utils to resolve NameError