### PR TITLE
Return LocationOut everywhere

### DIFF
--- a/backend/services/location_service.py
+++ b/backend/services/location_service.py
@@ -224,7 +224,8 @@ class LocationService:
             source="none",
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
-    logger.debug(
-        "✅ LocationService loaded with resolve_location=%s",
-        hasattr(LocationService, "resolve_location"),
-    )
+
+
+
+logger.debug("✅ LocationService loaded with resolve_location=%s", hasattr(LocationService, "resolve_location"))
+

--- a/scripts/retry_unresolved.py
+++ b/scripts/retry_unresolved.py
@@ -77,11 +77,13 @@ def main():
             skipped += 1
             continue
 
-        if result and result.get("lat") is not None:
-            log.info(f"✅ Geocode success: {result['raw_name']} → ({result['lat']}, {result['lng']})")
-            match.latitude = result["lat"]
-            match.longitude = result["lng"]
-            match.status = result.get("status", "geocoded")
+        if result and result.latitude is not None:
+            log.info(
+                f"✅ Geocode success: {result.raw_name} → ({result.latitude}, {result.longitude})"
+            )
+            match.latitude = result.latitude
+            match.longitude = result.longitude
+            match.status = getattr(result, "status", "geocoded")
             session.add(match)
             retried += 1
         else:

--- a/tests/features/test_basic_api.py
+++ b/tests/features/test_basic_api.py
@@ -6,10 +6,11 @@ def test_geocode_single_location():
     """✅ Test Geocode().get_or_create_location() directly."""
     geocoder = Geocode()
     result = geocoder.get_or_create_location(None, "Chicago, Illinois, USA")
-    assert result.get("latitude") is not None
-    assert result.get("longitude") is not None
-    assert "confidence_label" in result
-    assert "confidence_score" in result
+    assert result is not None
+    assert result.latitude is not None
+    assert result.longitude is not None
+    assert hasattr(result, "confidence_label")
+    assert hasattr(result, "confidence_score")
 
 
 def test_list_trees(client):

--- a/tests/scripts/test_fix_and_retry.py
+++ b/tests/scripts/test_fix_and_retry.py
@@ -66,5 +66,6 @@ def test_apply_manual_fixes_on_mock_data(tmp_path):
     assert norm_name in manual_fixes
 
     result = geo.get_or_create_location(None, "Ackerman, Choctaw, Mississippi, USA")
-    assert result["confidence_label"] == "manual"
-    assert result["latitude"] == 33.3037
+    assert result is not None
+    assert result.confidence_label == "manual"
+    assert result.latitude == 33.3037


### PR DESCRIPTION
## Summary
- return LocationOut objects from LocationService after class creation
- update retry script to use attributes from LocationOut
- fix tests to use attribute access with LocationOut

## Testing
- `pytest tests/features/test_basic_api.py::test_geocode_single_location -q`

------
https://chatgpt.com/codex/tasks/task_e_683f63f011e4832aa0b660ac1ff9d1c7

## Summary by Sourcery

Standardize LocationService to return LocationOut objects and update consuming code and tests to use attribute access

Enhancements:
- Return LocationOut instances from LocationService methods instead of raw dictionaries
- Update retry_unresolved script to use LocationOut attributes for geocoding results

Tests:
- Adapt tests to assert on LocationOut attribute access rather than dictionary keys