### PR TITLE
Fix unresolved path to use project directory

### DIFF
--- a/backend/utils/helpers.py
+++ b/backend/utils/helpers.py
@@ -8,6 +8,7 @@ import os
 import json
 import tempfile
 import logging
+from pathlib import Path
 from datetime import datetime
 from fuzzywuzzy import fuzz
 from sqlalchemy.orm import sessionmaker
@@ -105,7 +106,11 @@ def normalize_confidence_score(value):
     return 0.0
 
 
-UNRESOLVED_PATH = "/Users/kingal/mapem/backend/data/unresolved_locations.json"
+BASE_DIR = Path(__file__).resolve().parents[1]
+UNRESOLVED_PATH = os.getenv(
+    "UNRESOLVED_PATH",
+    str(BASE_DIR / "data" / "unresolved_locations.json"),
+)
 
 def generate_temp_path(suffix=".ged"):
     fd, path = tempfile.mkstemp(suffix=suffix, prefix="gedcom_", text=True)


### PR DESCRIPTION
## Summary
- remove hard-coded unresolved file path
- derive path from helpers.py location and allow override via `UNRESOLVED_PATH`

## Testing
- `pytest -q` *(fails: NameError in LocationService)*

------
https://chatgpt.com/codex/tasks/task_e_683f63f39eec832a8039713edc48b013

## Summary by Sourcery

Derive the path to unresolved_locations.json dynamically from the project directory and allow it to be overridden via the UNRESOLVED_PATH environment variable instead of using a hard-coded file path.

Enhancements:
- Remove hard-coded file path for unresolved locations and compute it relative to the helpers module's parent directory.
- Add support for overriding the unresolved locations path through the UNRESOLVED_PATH environment variable.