### PR TITLE
Add decade state in SearchContext

### DIFF
--- a/frontend/src/shared/context/SearchContext.jsx
+++ b/frontend/src/shared/context/SearchContext.jsx
@@ -31,6 +31,10 @@ export function SearchProvider({ children }) {
   const { treeId: activeTreeId } = useTree();
   const [filters, setFilters] = useState(defaultFilters);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [decade, setDecade] = useState([1900, 2020]);
+  const [mode, setMode] = useState('person');
+  const [wholeTree, setWholeTree] = useState(false);
+  const toggleWholeTree = () => setWholeTree((p) => !p);
 
   const [visibleCounts, setVisibleCounts] = useState({
     people: 0,
@@ -62,10 +66,16 @@ export function SearchProvider({ children }) {
       setFilters,
       isDrawerOpen,
       setIsDrawerOpen,
+      decade,
+      setDecade,
+      mode,
+      setMode,
+      wholeTree,
+      toggleWholeTree,
       clearAll,
       visibleCounts,
     }),
-    [filters, isDrawerOpen, visibleCounts]
+    [filters, isDrawerOpen, decade, mode, wholeTree, visibleCounts]
   );
 
   return (


### PR DESCRIPTION
## Summary
- add decade, mode, and wholeTree state to `SearchContext`
- expose setters and toggle in context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_683f67351930832ab55892d7942666ea

## Summary by Sourcery

Add decade range, mode selection, and whole-tree toggle state to SearchContext and expose the associated setters and toggle function through context.

New Features:
- Introduce decade state with setter to allow filtering by year range
- Add mode state with setter to switch search mode
- Add wholeTree boolean state with setter and toggleWholeTree function to control full-tree search