### PR TITLE
Sanitize env and add example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@ DB_PORT=5432
 
 DEBUG=true
 PORT=5050
-GOOGLE_MAPS_API_KEY=
-export GEOCODE_API_KEY=
+GOOGLE_MAPS_API_KEY=<your-key>
+export GEOCODE_API_KEY=<your-key>
 
 # Redis for Celery
 export CELERY_BROKER="redis://localhost:6379/0"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ frontend/frontend_patch_*.log
 
 # ─── Env & OS ───────────────────────────────────
 *.env
+.env
 .envrc
 .DS_Store
 __MACOSX

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ npm install            # installs deps (incl. dev tooling)
 npm run dev            # start Vite dev server
 ```
 
+### Environment setup
+Copy `.env.example` to `.env` and fill in any secrets before running the app:
+
+```bash
+cp .env.example .env
+# edit .env to add your API keys
+```
+
 ## 📂 Folder Map (high‑level)
 - **src/app/** – providers + router
 - **src/features/** – feature slices (map, people, analytics…)


### PR DESCRIPTION
## Summary
- remove secrets from `.env`
- add `.env.example` template
- ignore `.env`
- document env setup in README

## Testing
- `pytest -q` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_683f6759604c832aaa7eabcb31413bfe

## Summary by Sourcery

Add a `.env.example` template, remove sensitive data from version control, ignore the actual `.env` file, and document environment variable setup in the README

Documentation:
- Add an “Environment setup” section to README with instructions to copy and customize `.env` from `.env.example`

Chores:
- Remove secrets from `.env` and stop tracking it in Git
- Create `.env.example` template
- Update `.gitignore` to exclude `.env`