### PR TITLE
Use dynamic geocode cache path

### DIFF
--- a/backend/services/geocode.py
+++ b/backend/services/geocode.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime
 from urllib.parse import urlencode
 from typing import Optional, Dict, Any
+from pathlib import Path
 from pydantic import BaseModel
 
 from backend import models
@@ -38,26 +39,34 @@ def classify_location_failure(raw_name):
         return "typo_or_misspelling", "Moorhead, Sunflower, Mississippi, USA"
     return "geocode_failed", None
 
+DEFAULT_CACHE_PATH = Path(
+    os.getenv(
+        "GEOCODE_CACHE_FILE",
+        Path(__file__).resolve().parent.parent / "geocode_cache.json",
+    )
+)
+
+
 class Geocode:
     def __init__(
         self,
         api_key=None,
-        cache_file='geocode_cache.json',
-        use_cache=True,
+        cache_file: Optional[str | Path] = None,
+        use_cache: bool = True,
         manual_fixes=None,
-        historical_lookup=None
+        historical_lookup=None,
     ):
         self.api_key = api_key
-        self.cache_file = cache_file
+        self.cache_file = Path(cache_file or DEFAULT_CACHE_PATH)
         self.cache_enabled = use_cache
         self.cache = self._load_cache() if use_cache else {}
         self.manual_fixes = manual_fixes or {}
         self.historical_lookup = historical_lookup or {}
 
     def _load_cache(self):
-        if os.path.exists(self.cache_file):
+        if self.cache_file.exists():
             try:
-                with open(self.cache_file, 'r') as f:
+                with self.cache_file.open('r') as f:
                     return json.load(f)
             except json.JSONDecodeError:
                 logger.warning("⚠️ Cache file corrupted, starting fresh.")
@@ -66,7 +75,7 @@ class Geocode:
 
     def _save_cache(self):
         if self.cache_enabled:
-            with open(self.cache_file, 'w') as f:
+            with self.cache_file.open('w') as f:
                 json.dump(self.cache, f, indent=2)
 
     def _normalize_key(self, place):

--- a/scripts/load_cache_to_db.py
+++ b/scripts/load_cache_to_db.py
@@ -7,16 +7,19 @@ Read geocode_cache.json and upsert into the DB:
   - LOG ALL DECISIONS (inserted / updated / skipped) with reason
 """
 
-import json, os
+import json
+import os
+from pathlib import Path
 from datetime import datetime
 from backend.db import SessionLocal
 from backend.models import Location
 
-CACHE_FILE = os.path.join(os.path.dirname(__file__), "..", "geocode_cache.json")
+BASE_DIR = Path(__file__).resolve().parent.parent
+CACHE_FILE = Path(os.getenv("GEOCODE_CACHE_FILE", BASE_DIR / "geocode_cache.json"))
 
 def main():
     print(f"📂 Reading cache from {CACHE_FILE}")
-    cache = json.load(open(CACHE_FILE, "r"))
+    cache = json.load(CACHE_FILE.open("r"))
     session = SessionLocal()
 
     inserted = 0


### PR DESCRIPTION
## Summary
- derive `geocode_cache.json` path from `Path(__file__).resolve().parent` with optional `GEOCODE_CACHE_FILE` env var
- update geocoder cache loading and saving to use Path objects
- update `load_cache_to_db.py` to load cache via the new path source

## Testing
- `pytest -q` *(fails: sqlalchemy.exc...)*

------
https://chatgpt.com/codex/tasks/task_e_683f67628de8832ab64c3113017d4b53

## Summary by Sourcery

Use a dynamic geocode cache path based on an environment variable or package location and modernize cache handling to use pathlib in both the geocode service and the cache-loading script.

Enhancements:
- Derive default cache file path from GEOCODE_CACHE_FILE or the package directory
- Allow Geocode.cache_file to be initialized with a Path or string and default to the dynamic path
- Replace os.path and built-in open calls with Path.exists and Path.open in geocode cache load/save methods
- Update load_cache_to_db script to use pathlib for the cache path and honor the GEOCODE_CACHE_FILE override