### PR TITLE
Centralize logger setup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 import logging
-import sys
+from backend.utils.logger import get_logger
 from backend.routes import register_routes
 from backend.models import Base
 from backend.config import settings
@@ -11,18 +11,13 @@ from backend.db import get_engine, SessionLocal
 from backend.routes.heatmap import warmup_heatmap
 
 # ─── Logger Setup ───────────────────────────────────────────────
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger = get_logger(__name__)
 
 formatter = logging.Formatter("%(asctime)s — %(levelname)s — %(message)s")
 
 file_handler = logging.FileHandler("flask.log")
 file_handler.setFormatter(formatter)
 logger.addHandler(file_handler)
-
-console_handler = logging.StreamHandler(sys.stdout)
-console_handler.setFormatter(formatter)
-logger.addHandler(console_handler)
 
 # Optional: Capture SQLAlchemy engine warnings too
 logging.getLogger("sqlalchemy").setLevel(logging.WARNING)

--- a/backend/utils/helpers.py
+++ b/backend/utils/helpers.py
@@ -8,6 +8,7 @@ import os
 import json
 import tempfile
 import logging
+from backend.utils.logger import get_logger
 from datetime import datetime
 from fuzzywuzzy import fuzz
 from sqlalchemy.orm import sessionmaker
@@ -18,8 +19,7 @@ from backend.db import get_engine
 from backend.config import settings
 
 
-logger = logging.getLogger("helpers")
-logging.basicConfig(level=logging.DEBUG)
+logger = get_logger(__name__)
 from typing import Optional
 
 

--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -21,13 +21,21 @@ class ColorFormatter(logging.Formatter):
         record.levelname = _add_color(levelname, levelname)
         return super().format(record)
 
-def get_logger(name: str = "mapem", level: int = logging.DEBUG) -> logging.Logger:
-    logger = logging.getLogger(name)
-    if logger.handlers:
-        return logger  # already configured
 
-    logger.setLevel(level)
+def configure_logging(level: int = logging.DEBUG) -> None:
+    """Configure the root logger once."""
+    root = logging.getLogger()
+    if root.handlers:
+        return
+    root.setLevel(level)
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(ColorFormatter(_LOG_FORMAT))
-    logger.addHandler(handler)
+    root.addHandler(handler)
+
+
+def get_logger(name: str = "mapem", level: int = logging.DEBUG) -> logging.Logger:
+    """Return a logger that uses the central configuration."""
+    configure_logging(level)
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
     return logger


### PR DESCRIPTION
## Summary
- use `get_logger` in `helpers.py`
- configure logging once in `logger.py`
- simplify logging setup in `main.py`

## Testing
- `pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_683f67687cfc832aa7f9b6d4572fb0c9

## Summary by Sourcery

Centralize and simplify the application’s logging setup by extracting common configuration into a single function and standardizing logger creation.

Enhancements:
- Introduce `configure_logging` to initialize the root logger with a colored stream handler only once.
- Refactor `get_logger` to invoke the centralized configuration and enforce consistent log levels.
- Simplify `main.py` to use `get_logger` for logger instantiation and remove redundant handler setup.