### PR TITLE
Update heatmap path logic

### DIFF
--- a/backend/routes/heatmap.py
+++ b/backend/routes/heatmap.py
@@ -3,6 +3,7 @@
 import os
 import json
 import traceback
+from pathlib import Path
 from datetime import datetime
 from flask import Blueprint, request, jsonify, current_app
 from sqlalchemy import func
@@ -23,7 +24,8 @@ def load_shapes():
     global SHAPES_LOADED, SHAPES_INDEX
     if SHAPES_LOADED:
         return
-    base = os.path.join(os.getcwd(), "backend", "data", "historical_places")
+    base = Path(__file__).resolve().parent / ".." / "data" / "historical_places"
+    base = str(base)
     for root, _, files in os.walk(base):
         for fn in files:
             if fn.lower().endswith(".geojson"):


### PR DESCRIPTION
## Summary
- use pathlib to compute historical_places directory
- load shapes using resolved path

## Testing
- `pytest -q` *(fails: sqlalchemy.exc.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_683f676f570c832a8cc7bed4c5615ff3

## Summary by Sourcery

Refactor heatmap shape loader to use pathlib for resolving the historical_places data directory

Enhancements:
- Replace os.getcwd and os.path.join with pathlib.Path.resolve to compute the data directory path
- Convert the resolved Path object to string before walking the directory