### PR TITLE
Remove obsolete test route

### DIFF
--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -7,4 +7,5 @@ health_routes = Blueprint("health", __name__, url_prefix="/api")
 @health_routes.route("/ping", methods=["GET"])
 @debug_route
 def ping():
-    return jsonify({"status": "ok"}), 200
+    """Simple health check endpoint."""
+    return jsonify({"message": "pong"}), 200

--- a/backend/routes/test.py
+++ b/backend/routes/test.py
@@ -1,7 +1,0 @@
-from flask import Blueprint, jsonify
-
-test_bp = Blueprint("test", __name__)
-
-@test_bp.route("/api/ping", methods=["GET"])
-def ping():
-    return jsonify({"message": "pong"})


### PR DESCRIPTION
## Summary
- remove unused `test` blueprint
- consolidate health check route under `health.py`

## Testing
- `pytest -q` *(fails: sqlalchemy OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_683f678027a0832a8bd82d6d9bdc2628