### PR TITLE
Add mode selector and map wrappers

### DIFF
--- a/frontend/src/features/map/components/FamilyMap.jsx
+++ b/frontend/src/features/map/components/FamilyMap.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import MigrationMap from './MigrationMap';
+
+export default function FamilyMap(props) {
+  return <MigrationMap {...props} />;
+}

--- a/frontend/src/features/map/components/GroupMap.jsx
+++ b/frontend/src/features/map/components/GroupMap.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import MigrationMap from './MigrationMap';
+
+export default function GroupMap(props) {
+  return <MigrationMap {...props} />;
+}

--- a/frontend/src/features/map/components/PersonMap.jsx
+++ b/frontend/src/features/map/components/PersonMap.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import MigrationMap from './MigrationMap';
+
+export default function PersonMap(props) {
+  return <MigrationMap {...props} />;
+}

--- a/frontend/src/features/map/pages/MapPage.jsx
+++ b/frontend/src/features/map/pages/MapPage.jsx
@@ -3,21 +3,28 @@ import { getMovements } from "@lib/api/api"
 import { useTree }  from "@shared/context/TreeContext"
 import { useSearch } from "@shared/context/SearchContext"
 import { useMapControl } from "@shared/context/MapControlContext"
-import MigrationMap    from "@/features/map/components/MigrationMap"
+import ModeSelector    from "@shared/components/Header/ModeSelector"
 import FilterHeader    from "@shared/components/Header/FilterHeader"
+import AdvancedFilterDrawer from "@/features/map/components/AdvancedFilterDrawer"
 import LegendPanel     from "@/features/map/components/LegendPanel"
 import TypeSearch      from "@/features/map/components/TypeSearch"
 import PersonSelector  from "@/features/map/components/PersonSelector"
+import PersonMap       from "@/features/map/components/PersonMap"
+import FamilyMap       from "@/features/map/components/FamilyMap"
+import GroupMap        from "@/features/map/components/GroupMap"
 import { log as devLog } from "@/lib/api/devLogger.js"
 
 export default function MapPage() {
   const { treeId } = useTree()
-  const { filters, visibleCounts } = useSearch()
+  const { filters, visibleCounts, mode } = useSearch()
   const { activeSection, toggleSection } = useMapControl()
 
   const [movements, setMovements] = useState([])
   const [loading, setLoading]   = useState(false)
   const [error, setError]       = useState(null)
+
+  const MapComponent =
+    mode === "family" ? FamilyMap : mode === "compare" ? GroupMap : PersonMap
 
   // tree selection handled by TreeProvider
 
@@ -62,6 +69,7 @@ export default function MapPage() {
     <div className="relative w-full h-full">
       <div className="absolute top-4 left-1/2 -translate-x-1/2 z-50 w-[90vw] max-w-4xl">
         <FilterHeader>
+          <ModeSelector />
           {(activeSection === null || activeSection === "search") && <TypeSearch />}
           {activeSection === "person" && <PersonSelector />}
           {activeSection === null && (
@@ -76,7 +84,7 @@ export default function MapPage() {
       </div>
 
       {activeSection === "filters" && <AdvancedFilterDrawer />}
-      <MigrationMap movements={movements} loading={loading} error={error} />
+      <MapComponent movements={movements} loading={loading} error={error} />
       <LegendPanel
         movements={movements}
         people={visibleCounts.people}


### PR DESCRIPTION
## Summary
- add `PersonMap`, `FamilyMap`, and `GroupMap` wrappers
- render `<ModeSelector />` on `MapPage`
- switch maps based on selected mode

## Testing
- `pytest -q` *(fails: OperationalError connection refused)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845e93235c0832aac8ad493cc15d3bb

## Summary by Sourcery

Introduce mode-based map rendering in MapPage by adding map wrapper components and a mode selector to switch between person, family, and group views.

New Features:
- Add PersonMap, FamilyMap, and GroupMap wrapper components around MigrationMap
- Render ModeSelector in the MapPage header to allow mode selection
- Dynamically select and render the appropriate map wrapper based on the chosen mode

Enhancements:
- Refactor MapPage to use a MapComponent variable for cleaner conditional rendering