### PR TITLE
Add family/compare selectors and mode-aware legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,27 @@ cp .env.example .env
 - **src/features/** – feature slices (map, people, analytics…)
 - **src/shared/** – design‑system, contexts, hooks, styles
 - **src/lib/** – API clients & helper libs
+
+## Selector Usage Example
+
+The `SearchContext` exposes `selectedFamilyId` and `compareIds` for advanced
+filter modes. Pair the context with selector components to choose people,
+families or comparison groups:
+
+```jsx
+import PersonSelector from '@/features/map/components/PersonSelector';
+import FamilySelector from '@/features/map/components/FamilySelector';
+import GroupSelector  from '@/features/map/components/GroupSelector';
+import { useSearch } from '@/shared/context/SearchContext';
+
+function MapControls() {
+  const { mode } = useSearch();
+  return (
+    <>
+      {mode === 'person' && <PersonSelector />}
+      {mode === 'family' && <FamilySelector />}
+      {mode === 'compare' && <GroupSelector />}
+    </>
+  );
+}
+```

--- a/frontend/src/features/map/components/FamilySelector.jsx
+++ b/frontend/src/features/map/components/FamilySelector.jsx
@@ -28,7 +28,7 @@ export default function FamilySelector() {
 
   return (
     <div className={`transition-all ${open ? 'w-full' : 'w-40'} bg-[var(--surface)] border border-white/10 rounded overflow-hidden`}>
-      <ul className="divide-y divide-white/10">
+      <ul className="max-h-60 overflow-y-auto divide-y divide-white/10">
         {results.map((f) => (
           <li key={f.id}>
             <button

--- a/frontend/src/features/map/components/FamilySelector.jsx
+++ b/frontend/src/features/map/components/FamilySelector.jsx
@@ -12,7 +12,13 @@ export default function FamilySelector() {
 
   useEffect(() => {
     if (filters.person.trim().length < 2) return setResults([]);
-    api.search(filters.person).then(setResults);
+    api.search(filters.person)
+      .then(setResults)
+      .catch((err) => {
+        // You can replace this with a toast or error UI if desired
+        console.error('Failed to search families:', err);
+        setResults([]);
+      });
   }, [filters.person]);
 
   const handleSelect = (family) => {

--- a/frontend/src/features/map/components/FamilySelector.jsx
+++ b/frontend/src/features/map/components/FamilySelector.jsx
@@ -1,0 +1,39 @@
+// src/features/map/components/FamilySelector.jsx
+import React, { useState, useEffect } from 'react';
+import { useMapControl } from '@shared/context/MapControlContext';
+import { useSearch } from '@shared/context/SearchContext';
+import * as api from '@lib/api/api';
+
+export default function FamilySelector() {
+  const { activeSection, toggleSection } = useMapControl();
+  const { filters, setFilters } = useSearch();
+  const open = activeSection === 'family';
+  const [results, setResults] = useState([]);
+
+  useEffect(() => {
+    if (filters.person.trim().length < 2) return setResults([]);
+    api.search(filters.person).then(setResults);
+  }, [filters.person]);
+
+  const handleSelect = (family) => {
+    setFilters((prev) => ({ ...prev, selectedFamilyId: family.id }));
+    toggleSection('family');
+  };
+
+  return (
+    <div className={`transition-all ${open ? 'w-full' : 'w-40'} bg-[var(--surface)] border border-white/10 rounded overflow-hidden`}>
+      <ul className="divide-y divide-white/10">
+        {results.map((f) => (
+          <li key={f.id}>
+            <button
+              onClick={() => handleSelect(f)}
+              className="w-full text-left px-3 py-2 hover:bg-white/10 transition"
+            >
+              {f.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/features/map/components/GroupSelector.jsx
+++ b/frontend/src/features/map/components/GroupSelector.jsx
@@ -1,0 +1,55 @@
+// src/features/map/components/GroupSelector.jsx
+import React, { useState, useEffect } from 'react';
+import { useMapControl } from '@shared/context/MapControlContext';
+import { useSearch } from '@shared/context/SearchContext';
+import * as api from '@lib/api/api';
+
+export default function GroupSelector() {
+  const { activeSection, toggleSection } = useMapControl();
+  const { filters, setFilters } = useSearch();
+  const open = activeSection === 'compare';
+  const [results, setResults] = useState([]);
+
+  useEffect(() => {
+    if (filters.person.trim().length < 2) return setResults([]);
+    api.search(filters.person).then(setResults);
+  }, [filters.person]);
+
+  const toggleId = (id) => {
+    setFilters((prev) => {
+      const exists = prev.compareIds.includes(id);
+      const compareIds = exists
+        ? prev.compareIds.filter((v) => v !== id)
+        : [...prev.compareIds, id];
+      return { ...prev, compareIds };
+    });
+  };
+
+  const done = () => toggleSection('compare');
+
+  return (
+    <div className={`transition-all ${open ? 'w-full' : 'w-40'} bg-[var(--surface)] border border-white/10 rounded overflow-hidden`}>
+      <ul className="divide-y divide-white/10 max-h-60 overflow-y-auto">
+        {results.map((p) => (
+          <li key={p.id} className="flex items-center">
+            <label className="flex-1 px-3 py-2 hover:bg-white/10">
+              <input
+                type="checkbox"
+                checked={filters.compareIds.includes(p.id)}
+                onChange={() => toggleId(p.id)}
+                className="mr-2"
+              />
+              {p.name}
+            </label>
+          </li>
+        ))}
+      </ul>
+      <button
+        onClick={done}
+        className="w-full bg-accent/20 hover:bg-accent/40 rounded-lg py-1 text-sm mt-2 transition text-white"
+      >
+        Done
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/features/map/components/LegendPanel.jsx
+++ b/frontend/src/features/map/components/LegendPanel.jsx
@@ -32,8 +32,10 @@ export default function LegendPanel() {
           items.push(['👤', 'People', counts.people]);
         if (mode === 'family')
           items.push(['👪', 'Families', counts.families]);
-        if (mode === 'person' && filters.selectedPersonId)
+        if (mode === 'person' && filters.selectedPersonId) {
           items.push(['🏠', 'Household', counts.household]);
+        }
+
         items.push(['🌳', 'Whole Tree', counts.wholeTree]);
         return items;
       })()

--- a/frontend/src/features/map/components/LegendPanel.jsx
+++ b/frontend/src/features/map/components/LegendPanel.jsx
@@ -7,7 +7,7 @@ import { devLog } from '@shared/utils/devLogger';
 
 export default function LegendPanel() {
   const { counts } = useLegend();
-  const { filters } = useSearch();
+  const { filters, mode } = useSearch();
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -26,13 +26,17 @@ export default function LegendPanel() {
     >
       <h3 className="font-semibold mb-1 text-white">Legend</h3>
 
-      {[
-        ['👤', 'People', counts.people],
-        ['👪', 'Families', counts.families],
-        filters.selectedPersonId && ['🏠', 'Household', counts.household],
-        ['🌳', 'Whole Tree', counts.wholeTree],
-      ]
-        .filter(Boolean)
+      {(() => {
+        const items = [];
+        if (mode === 'person' || mode === 'compare')
+          items.push(['👤', 'People', counts.people]);
+        if (mode === 'family')
+          items.push(['👪', 'Families', counts.families]);
+        if (mode === 'person' && filters.selectedPersonId)
+          items.push(['🏠', 'Household', counts.household]);
+        items.push(['🌳', 'Whole Tree', counts.wholeTree]);
+        return items;
+      })()
         .map(([icon, label, value]) => (
           <div key={label} className="flex justify-between text-white">
             <div className="flex items-center">

--- a/frontend/src/shared/context/LegendContext.jsx
+++ b/frontend/src/shared/context/LegendContext.jsx
@@ -9,7 +9,7 @@ const LegendContext = createContext(null);
 export const useLegend = () => useContext(LegendContext);
 
 export function LegendProvider({ children }) {
-  const { filters } = useSearch();
+  const { filters, mode } = useSearch();
   const { treeId } = useTree();
   const [counts, setCounts] = useState({
     people: 0,
@@ -38,7 +38,7 @@ export function LegendProvider({ children }) {
   // 2) Visible counts
   useEffect(() => {
     if (!treeId) return;
-    devLog("LegendContext", "🔍 Fetching visible counts for", filters);
+    devLog("LegendContext", "🔍 Fetching visible counts for", { mode, filters });
     api.getVisibleCounts(treeId, filters)
     .then((res) => {
       devLog("LegendContext", "✅ Got visible counts", res);
@@ -47,7 +47,7 @@ export function LegendProvider({ children }) {
       setCounts((c) => ({ ...c, people, families }));
     })
         .catch((err) => devLog("LegendContext", "❌ getVisibleCounts failed", err));
-  }, [treeId, filters]);
+  }, [treeId, filters, mode]);
 
   // 3) Household size
   useEffect(() => {

--- a/frontend/src/shared/context/SearchContext.jsx
+++ b/frontend/src/shared/context/SearchContext.jsx
@@ -21,6 +21,8 @@ const defaultFilters = {
   },
   relations: {},
   sources: {},
+  selectedFamilyId: null,
+  compareIds: [],
 };
 
 const defaultCtx = {


### PR DESCRIPTION
## Summary
- allow SearchContext filters to track `selectedFamilyId` and `compareIds`
- add new `FamilySelector` and `GroupSelector` components for family and compare modes
- update legend counts based on active mode
- document example usage of selectors

## Testing
- `pytest -q` *(fails: OperationalError connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6845e93575b8832aaff1b529e8f28d3a

## Summary by Sourcery

Add family and comparison selector components, extend search filters for family and compare modes, and update the legend to display counts contextually based on the current mode.

New Features:
- Extend SearchContext to track selectedFamilyId and compareIds filters
- Add FamilySelector component for choosing a family in family mode
- Add GroupSelector component for selecting comparison groups in compare mode

Enhancements:
- Make LegendPanel mode-aware to show counts relevant to person, family, or compare modes
- Update LegendContext to include mode in its dependency and logging for visible counts

Documentation:
- Document selector usage example in README