### PR TITLE
Enable mode-based map fetching

### DIFF
--- a/frontend/src/features/map/pages/MapPage.jsx
+++ b/frontend/src/features/map/pages/MapPage.jsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useState } from "react"
-import { getMovements } from "@lib/api/api"
+import {
+  getMovements,
+  getFamilyMovements,
+  getGroupMovements,
+} from "@lib/api/api"
 import { useTree }  from "@shared/context/TreeContext"
 import { useSearch } from "@shared/context/SearchContext"
 import { useMapControl } from "@shared/context/MapControlContext"
@@ -9,6 +13,8 @@ import AdvancedFilterDrawer from "@/features/map/components/AdvancedFilterDrawer
 import LegendPanel     from "@/features/map/components/LegendPanel"
 import TypeSearch      from "@/features/map/components/TypeSearch"
 import PersonSelector  from "@/features/map/components/PersonSelector"
+import FamilySelector  from "@/features/map/components/FamilySelector"
+import GroupSelector   from "@/features/map/components/GroupSelector"
 import PersonMap       from "@/features/map/components/PersonMap"
 import FamilyMap       from "@/features/map/components/FamilyMap"
 import GroupMap        from "@/features/map/components/GroupMap"
@@ -34,9 +40,18 @@ export default function MapPage() {
 
     setLoading(true)
     setError(null)
-    devLog("[🗺️ Fetching movements]", treeId, filters)
+    devLog("[🗺️ Fetching movements]", treeId, filters, mode)
 
-    getMovements(treeId, filters)
+    const { selectedFamilyId, compareIds, ...baseFilters } = filters
+
+    const fetcher =
+      mode === "family"
+        ? getFamilyMovements(treeId, selectedFamilyId, baseFilters)
+        : mode === "compare"
+        ? getGroupMovements(treeId, compareIds, baseFilters)
+        : getMovements(treeId, baseFilters)
+
+    fetcher
       .then(data => {
         // if API returns flat segments array:
         let segments = []
@@ -72,6 +87,8 @@ export default function MapPage() {
           <ModeSelector />
           {(activeSection === null || activeSection === "search") && <TypeSearch />}
           {activeSection === "person" && <PersonSelector />}
+          {activeSection === "family" && <FamilySelector />}
+          {activeSection === "compare" && <GroupSelector />}
           {activeSection === null && (
             <button
               onClick={() => toggleSection("filters")}

--- a/frontend/src/shared/context/MapControlContext.jsx
+++ b/frontend/src/shared/context/MapControlContext.jsx
@@ -5,7 +5,7 @@ const MapControlContext = createContext(null);
 export const useMapControl = () => useContext(MapControlContext);
 
 export function MapControlProvider({ children }) {
-  const [activeSection, setActiveSection] = useState(null); // 'search' | 'person' | 'filters' | null
+  const [activeSection, setActiveSection] = useState(null); // 'search' | 'person' | 'family' | 'compare' | 'filters' | null
   const toggleSection = (section) => setActiveSection((p) => (p === section ? null : section));
   const value = useMemo(() => ({ activeSection, toggleSection }), [activeSection]);
   return <MapControlContext.Provider value={value}>{children}</MapControlContext.Provider>;

--- a/frontend/src/shared/context/SearchContext.jsx
+++ b/frontend/src/shared/context/SearchContext.jsx
@@ -21,6 +21,7 @@ const defaultFilters = {
   },
   relations: {},
   sources: {},
+  selectedPersonId: null,
   selectedFamilyId: null,
   compareIds: [],
 };


### PR DESCRIPTION
## Summary
- extend `defaultFilters` with `selectedPersonId`
- support family/compare sections in `MapControlContext`
- fetch movements per mode in `MapPage`
- expose selectors for family and compare modes in header

## Testing
- `pytest -q` *(fails: OperationalError)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845e5735200832ab2b6e0cea2457a2f