### PR TITLE
Add geocode admin dashboard

### DIFF
--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -19,6 +19,7 @@ from backend.routes.movements import movements_routes
 from backend.routes.health    import health_routes
 from backend.routes.heatmap   import heatmap_routes
 from backend.routes.geocode_api import bp as geocode_routes  # ← NEW
+from backend.routes.geocode_dashboard import geocode_dashboard
 
 from backend.utils.debug_routes import debug_route
 
@@ -39,6 +40,7 @@ def register_routes(app):
         health_routes,
         heatmap_routes,
         geocode_routes,        # ← NEW
+        geocode_dashboard,
     ]
 
     for bp in routes:

--- a/backend/routes/geocode_dashboard.py
+++ b/backend/routes/geocode_dashboard.py
@@ -1,0 +1,66 @@
+"""Admin dashboard for geocode statistics and manual fixes."""
+
+from flask import Blueprint, render_template, request, redirect, url_for
+from sqlalchemy import func
+
+from backend.db import SessionLocal
+from backend.models.location import Location
+from backend.models.enums import LocationStatusEnum
+from backend.utils.logger import get_file_logger
+
+logger = get_file_logger("geocode_dashboard")
+
+geocode_dashboard = Blueprint(
+    "geocode_dashboard",
+    __name__,
+    url_prefix="/admin/geocode",
+    template_folder="../templates",
+)
+
+
+@geocode_dashboard.route("/", methods=["GET"], strict_slashes=False)
+def show_dashboard():
+    """Display simple geocode statistics."""
+    db = SessionLocal()
+    try:
+        stats = (
+            db.query(Location.status, func.count(Location.id))
+            .group_by(Location.status)
+            .all()
+        )
+        stats_dict = {str(status): count for status, count in stats}
+    finally:
+        db.close()
+    return render_template("geocode_dashboard.html", stats=stats_dict)
+
+
+@geocode_dashboard.route("/manual-fix", methods=["POST"], strict_slashes=False)
+def manual_fix():
+    """Apply a simple manual latitude/longitude override."""
+    loc_id = request.form.get("id", type=int)
+    lat = request.form.get("lat", type=float)
+    lng = request.form.get("lng", type=float)
+
+    if not loc_id or lat is None or lng is None:
+        logger.warning("⚠️ manual_fix missing parameters")
+        return redirect(url_for("geocode_dashboard.show_dashboard"))
+
+    db = SessionLocal()
+    try:
+        loc = db.query(Location).get(loc_id)
+        if loc:
+            loc.latitude = lat
+            loc.longitude = lng
+            loc.status = LocationStatusEnum.manual_override
+            db.commit()
+            logger.info("🔧 manual override applied to location %s", loc_id)
+        else:
+            logger.warning("⚠️ Location %s not found", loc_id)
+    except Exception:
+        db.rollback()
+        logger.exception("💥 failed manual fix")
+    finally:
+        db.close()
+
+    return redirect(url_for("geocode_dashboard.show_dashboard"))
+

--- a/backend/services/geocode/__init__.py
+++ b/backend/services/geocode/__init__.py
@@ -1,7 +1,8 @@
 # ✅ backend/services/geocode/__init__.py
 from .geocode import Geocode, GEOCODER
+from backend.models.location_models import LocationOut
 
 def get_geocoder():
     return GEOCODER
 
-__all__ = ["Geocode", "GEOCODER", "get_geocoder"]
+__all__ = ["Geocode", "GEOCODER", "get_geocoder", "LocationOut"]

--- a/backend/templates/geocode_dashboard.html
+++ b/backend/templates/geocode_dashboard.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+    <title>Geocode Dashboard</title>
+</head>
+<body>
+    <h1>Geocode Dashboard</h1>
+
+    <h2>Statistics</h2>
+    <ul>
+    {% for status, count in stats.items() %}
+        <li>{{ status }}: {{ count }}</li>
+    {% else %}
+        <li>No data available</li>
+    {% endfor %}
+    </ul>
+
+    <h2>Manual Fix</h2>
+    <form method="POST" action="{{ url_for('geocode_dashboard.manual_fix') }}">
+        <label>Location ID: <input name="id" type="number" required></label><br>
+        <label>Latitude: <input name="lat" type="text" required></label><br>
+        <label>Longitude: <input name="lng" type="text" required></label><br>
+        <button type="submit">Submit Fix</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add geocode dashboard blueprint with simple stats and manual fix form
- export `LocationOut` in geocode service init
- register new blueprint
- create basic template for dashboard

## Testing
- `pytest -q` *(fails: OperationalError connecting to DB)*

------
https://chatgpt.com/codex/tasks/task_e_6848a2da5f58832aa30572ced24bd7e1