### PR TITLE
Add analytics snapshot panel

### DIFF
--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -20,6 +20,7 @@ from backend.routes.health    import health_routes
 from backend.routes.heatmap   import heatmap_routes
 from backend.routes.geocode_api import bp as geocode_routes  # ← NEW
 from backend.routes.geocode_dashboard import geocode_dashboard
+from backend.routes.analytics import analytics_routes
 
 from backend.utils.debug_routes import debug_route
 
@@ -39,6 +40,7 @@ def register_routes(app):
         movements_routes,
         health_routes,
         heatmap_routes,
+        analytics_routes,
         geocode_routes,        # ← NEW
         geocode_dashboard,
     ]

--- a/backend/routes/analytics.py
+++ b/backend/routes/analytics.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from flask import Blueprint, jsonify
+from sqlalchemy import func
+
+from backend.db import SessionLocal
+from backend.models import Location, UploadedTree
+from backend.models.enums import LocationStatusEnum
+
+analytics_routes = Blueprint("analytics", __name__, url_prefix="/api/analytics")
+
+@analytics_routes.route("/snapshot", methods=["GET"])
+def system_snapshot():
+    db = SessionLocal()
+    try:
+        total = db.query(func.count(Location.id)).scalar() or 0
+        resolved = (
+            db.query(func.count(Location.id))
+            .filter(Location.status == LocationStatusEnum.ok)
+            .scalar()
+            or 0
+        )
+        unresolved = (
+            db.query(func.count(Location.id))
+            .filter(Location.status == LocationStatusEnum.unresolved)
+            .scalar()
+            or 0
+        )
+        manual = (
+            db.query(func.count(Location.id))
+            .filter(Location.status == LocationStatusEnum.manual_override)
+            .scalar()
+            or 0
+        )
+        # not all schemas may have a "fail" status
+        failed = (
+            db.query(func.count(Location.id))
+            .filter(Location.status == "fail")
+            .scalar()
+            or 0
+        )
+
+        last_upload = db.query(func.max(UploadedTree.created_at)).scalar()
+        last_manual_fix = (
+            db.query(func.max(Location.updated_at))
+            .filter(Location.status == LocationStatusEnum.manual_override)
+            .scalar()
+        )
+
+        return (
+            jsonify(
+                {
+                    "total_locations": total,
+                    "resolved": resolved,
+                    "unresolved": unresolved,
+                    "manual_fixes": manual,
+                    "failed": failed,
+                    "last_upload": last_upload.isoformat() if last_upload else None,
+                    "last_manual_fix": last_manual_fix.isoformat() if last_manual_fix else None,
+                }
+            ),
+            200,
+        )
+    finally:
+        db.close()

--- a/frontend/src/features/analytics/components/SystemSnapshot.jsx
+++ b/frontend/src/features/analytics/components/SystemSnapshot.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import Card from '@shared/components/ui/Card';
+import { getSystemSnapshot } from '@lib/api/api';
+
+export default function SystemSnapshot() {
+  const [stats, setStats] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getSystemSnapshot()
+      .then(setStats)
+      .catch(err => {
+        console.error('Snapshot fetch failed', err);
+        setError('Failed to load system snapshot');
+      });
+  }, []);
+
+  if (error) {
+    return <Card className="text-red-300">{error}</Card>;
+  }
+
+  if (!stats) {
+    return <Card>Loading snapshot...</Card>;
+  }
+
+  const entries = [
+    { label: 'Total Locations', value: stats.total_locations },
+    { label: 'Resolved (OK)', value: stats.resolved },
+    { label: 'Unresolved', value: stats.unresolved },
+    { label: 'Manual Fixes', value: stats.manual_fixes },
+    { label: 'Failed', value: stats.failed },
+  ];
+
+  return (
+    <Card className="space-y-2">
+      <h3 className="text-lg font-semibold mb-2">System Snapshot</h3>
+      <ul className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+        {entries.map((e) => (
+          <li key={e.label} className="flex justify-between">
+            <span>{e.label}</span>
+            <span className="font-mono">{e.value}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="text-xs text-neutral-400 pt-2">
+        Last Upload: {stats.last_upload || 'N/A'}<br />
+        Last Manual Fix: {stats.last_manual_fix || 'N/A'}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/features/analytics/pages/AnalyticsPage.jsx
+++ b/frontend/src/features/analytics/pages/AnalyticsPage.jsx
@@ -1,16 +1,20 @@
 import React, { useEffect } from "react";
+import SystemSnapshot from "../components/SystemSnapshot";
 
 export default function Analytics() {
   useEffect(() => {
     if (import.meta.env.DEV) console.log("📊 [Analytics] mounted");
   }, []);
   return (
-    <div className="p-6">
-      <h2 className="text-2xl font-bold mb-4">Analytics (Coming Soon)</h2>
-      <p className="text-neutral-400">
-        Migration stats, unresolved location metrics, and insights will live
-        here.
-      </p>
+    <div className="p-6 space-y-6">
+      <SystemSnapshot />
+      <div>
+        <h2 className="text-2xl font-bold mb-4">Analytics (Coming Soon)</h2>
+        <p className="text-neutral-400">
+          Migration stats, unresolved location metrics, and insights will live
+          here.
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/lib/api/api.js
+++ b/frontend/src/lib/api/api.js
@@ -106,3 +106,7 @@ export const getGroupMovements = (treeId, filters = {}) =>
     params: filters,
     paramsSerializer: p => qs.stringify(p, { arrayFormat: 'repeat', skipNulls: true }),
   }));
+
+// ─── analytics ─────────────────────────────────────────────────────────────
+export const getSystemSnapshot = () =>
+  ok(client.get('/api/analytics/snapshot'));

--- a/tests/routes/test_analytics.py
+++ b/tests/routes/test_analytics.py
@@ -1,0 +1,23 @@
+from backend.models import Location, UploadedTree
+from backend.models.enums import LocationStatusEnum
+
+
+def test_system_snapshot(client, db_session):
+    # Setup sample data
+    loc1 = Location(raw_name="A", normalized_name="a", status=LocationStatusEnum.ok)
+    loc2 = Location(raw_name="B", normalized_name="b", status=LocationStatusEnum.unresolved)
+    loc3 = Location(raw_name="C", normalized_name="c", status=LocationStatusEnum.manual_override)
+    db_session.add_all([loc1, loc2, loc3])
+    tree = UploadedTree(tree_name="T")
+    db_session.add(tree)
+    db_session.commit()
+
+    resp = client.get("/api/analytics/snapshot")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data["total_locations"] == 3
+    assert data["resolved"] == 1
+    assert data["unresolved"] == 1
+    assert data["manual_fixes"] == 1
+    assert "last_upload" in data


### PR DESCRIPTION
## Summary
- add API to compute simple location stats
- register analytics blueprint
- expose `getSystemSnapshot` client API
- display new stats in Analytics page via `SystemSnapshot` component
- test new endpoint

## Testing
- `pytest -q` *(fails: connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_684980898b24832a928b62d0a999ba83