### PR TITLE
Switch location FK to UUID type

### DIFF
--- a/backend/models/alternate_name.py
+++ b/backend/models/alternate_name.py
@@ -1,6 +1,8 @@
 # backend/models/alternate_name.py
 from sqlalchemy import Column, Integer, String, ForeignKey
 from sqlalchemy.orm import relationship
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
 from .base import Base, TimestampMixin, ReprMixin
 
 class AlternateName(Base, TimestampMixin, ReprMixin):
@@ -8,7 +10,7 @@ class AlternateName(Base, TimestampMixin, ReprMixin):
 
     id           = Column(Integer, primary_key=True, autoincrement=True)
     location_id  = Column(
-        Integer,
+        UUID(as_uuid=True),
         ForeignKey("locations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/backend/models/event.py
+++ b/backend/models/event.py
@@ -37,7 +37,7 @@ class Event(Base, ReprMixin):
     notes          = Column(String)
     source_tag     = Column(String)
     category       = Column(String)
-    location_id    = Column(Integer, ForeignKey("locations.id", ondelete="SET NULL"), index=True)
+    location_id    = Column(UUID(as_uuid=True), ForeignKey("locations.id", ondelete="SET NULL"), index=True)
 
     # ─── Relationships ───────────────────────────────────
     tree           = relationship("TreeVersion", back_populates="events", lazy="joined")

--- a/backend/models/individual.py
+++ b/backend/models/individual.py
@@ -103,7 +103,7 @@ class ResidenceHistory(Base, TimestampMixin, ReprMixin):
         index=True,
     )
     location_id = Column(
-        Integer,
+        UUID(as_uuid=True),
         ForeignKey("locations.id", ondelete="SET NULL"),
         nullable=True,
         index=True,

--- a/backend/models/location.py
+++ b/backend/models/location.py
@@ -2,7 +2,6 @@
 
 from sqlalchemy import (
     Column,
-    Integer,
     String,
     Float,
     DateTime,
@@ -11,11 +10,12 @@ from sqlalchemy import (
     Enum,
 )
 from sqlalchemy.orm import relationship
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
 from datetime import datetime
 from backend.models.base import Base, UUIDMixin
 from .enums import SourceTypeEnum, LocationStatusEnum
 from sqlalchemy import Enum as SQLEnum   # give it a short alias
-from sqlalchemy import Column, String, DateTime
 
 class Location(Base, UUIDMixin):
     __tablename__ = "locations"
@@ -25,7 +25,7 @@ class Location(Base, UUIDMixin):
         CheckConstraint("longitude BETWEEN -180 AND 180", name="chk_lng_range"),
     )
 
-    id               = Column(Integer, primary_key=True, autoincrement=True)
+    id               = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     raw_name         = Column(String, nullable=False)
     normalized_name  = Column(String, nullable=False, unique=True)
     latitude         = Column(Float, nullable=True)


### PR DESCRIPTION
## Summary
- change `Location.id` to use UUIDs
- update `location_id` columns in related models to match

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: sqlalchemy.exc.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_684d170e9808832a8a22e1d3fcd0c2df

## Summary by Sourcery

Switch Location primary key to UUID and update all related foreign keys in models to use UUID references.

Enhancements:
- Use UUID primary key for Location model instead of integer autoincrement
- Update location_id columns in AlternateName, Event, and ResidenceHistory models to reference UUIDs