### PR TITLE
Switch AlternateName to UUID fields

### DIFF
--- a/backend/models/alternate_name.py
+++ b/backend/models/alternate_name.py
@@ -1,14 +1,17 @@
 # backend/models/alternate_name.py
-from sqlalchemy import Column, Integer, String, ForeignKey
+import uuid
+
+from sqlalchemy import Column, String, ForeignKey
 from sqlalchemy.orm import relationship
+from sqlalchemy.dialects.postgresql import UUID
 from .base import Base, TimestampMixin, ReprMixin
 
 class AlternateName(Base, TimestampMixin, ReprMixin):
     __tablename__ = "alternate_names"
 
-    id           = Column(Integer, primary_key=True, autoincrement=True)
-    location_id  = Column(
-        Integer,
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    location_id = Column(
+        UUID(as_uuid=True),
         ForeignKey("locations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,


### PR DESCRIPTION
## Summary
- use UUID columns for AlternateName model fields

## Testing
- `pytest -q` *(fails: sqlalchemy OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_684d17101eac832aae078f9667663d30

## Summary by Sourcery

Switch the AlternateName model to use UUID fields for its primary key and foreign key columns.

Enhancements:
- Replace integer autoincrement id with a UUID primary key using uuid.uuid4 defaults
- Change location_id foreign key to use UUID type with cascade deletes