### PR TITLE
Switch events to UUID

### DIFF
--- a/backend/models/event.py
+++ b/backend/models/event.py
@@ -14,7 +14,12 @@ import uuid
 event_participants = Table(
     "event_participants",
     Base.metadata,
-    Column("event_id", ForeignKey("events.id", ondelete="CASCADE"), primary_key=True),
+    Column(
+        "event_id",
+        UUID(as_uuid=True),
+        ForeignKey("events.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
     Column("individual_id", ForeignKey("individuals.id", ondelete="CASCADE"), primary_key=True),
 )
 
@@ -24,7 +29,7 @@ class Event(Base, ReprMixin):
         Index("ix_events_tree_date", "tree_id", "date"),
     )
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tree_id = Column(
         UUID(as_uuid=True),
         ForeignKey("tree_versions.id", ondelete="CASCADE"),
@@ -37,7 +42,11 @@ class Event(Base, ReprMixin):
     notes          = Column(String)
     source_tag     = Column(String)
     category       = Column(String)
-    location_id    = Column(Integer, ForeignKey("locations.id", ondelete="SET NULL"), index=True)
+    location_id    = Column(
+        UUID(as_uuid=True),
+        ForeignKey("locations.id", ondelete="SET NULL"),
+        index=True,
+    )
 
     # ─── Relationships ───────────────────────────────────
     tree           = relationship("TreeVersion", back_populates="events", lazy="joined")

--- a/backend/models/event_source.py
+++ b/backend/models/event_source.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     ForeignKey,
     UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from .base import Base, TimestampMixin, ReprMixin
 
@@ -17,7 +18,7 @@ class EventSource(Base, TimestampMixin, ReprMixin):
 
     id         = Column(Integer, primary_key=True, autoincrement=True)
     event_id   = Column(
-        Integer,
+        UUID(as_uuid=True),
         ForeignKey("events.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/backend/models/user_action.py
+++ b/backend/models/user_action.py
@@ -39,7 +39,7 @@ class UserAction(Base, TimestampMixin, ReprMixin):
         index=True,
     )
     event_id         = Column(
-        Integer,
+        UUID(as_uuid=True),
         ForeignKey("events.id", ondelete="SET NULL"),
         nullable=True,
         index=True,


### PR DESCRIPTION
## Summary
- use UUID PK for `Event`
- type `event_participants.event_id` as UUID
- update `EventSource.event_id` and `UserAction.event_id`

## Testing
- `pytest -q` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684d1717af74832a977c795768b64845

## Summary by Sourcery

Migrate Event primary key and related foreign key columns to UUID for stronger ID consistency

Enhancements:
- Change Event.id to a UUID primary key with a default uuid4 generator
- Convert event_participants.event_id, EventSource.event_id, and UserAction.event_id columns to UUID types
- Update Event.location_id to use UUID with corresponding foreign key constraint