### PR TITLE
Fix ResidenceHistory location_id type

### DIFF
--- a/backend/models/individual.py
+++ b/backend/models/individual.py
@@ -103,7 +103,7 @@ class ResidenceHistory(Base, TimestampMixin, ReprMixin):
         index=True,
     )
     location_id = Column(
-        Integer,
+        UUID(as_uuid=True),
         ForeignKey("locations.id", ondelete="SET NULL"),
         nullable=True,
         index=True,


### PR DESCRIPTION
## Summary
- use UUID type for `location_id` in `ResidenceHistory`

## Testing
- `pytest -q` *(fails: sqlalchemy OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_684d171b8048832aa202b9b49f60a24d

## Summary by Sourcery

Bug Fixes:
- Change ResidenceHistory.location_id column type from Integer to UUID