### PR TITLE
Remove visibleCounts from MapPage

### DIFF
--- a/frontend/src/features/map/pages/MapPage.jsx
+++ b/frontend/src/features/map/pages/MapPage.jsx
@@ -19,12 +19,11 @@ import PersonMap       from "@/features/map/components/PersonMap"
 import FamilyMap       from "@/features/map/components/FamilyMap"
 import GroupMap        from "@/features/map/components/GroupMap"
 import { log as devLog } from "@/lib/api/devLogger.js"
-import MigrationMap from "@/features/map/components/MigrationMap";
 
 
 export default function MapPage() {
   const { treeId } = useTree()
-  const { filters, visibleCounts, mode } = useSearch()
+  const { filters, mode } = useSearch()
   const { activeSection, toggleSection } = useMapControl()
 
   const [movements, setMovements] = useState([])
@@ -104,11 +103,7 @@ export default function MapPage() {
 
       {activeSection === "filters" && <AdvancedFilterDrawer />}
       <MapComponent movements={movements} loading={loading} error={error} />
-      <LegendPanel
-        movements={movements}
-        people={visibleCounts.people}
-        families={visibleCounts.families}
-      />
+      <LegendPanel />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- clean up MapPage to rely on LegendContext
- drop unused MigrationMap import

## Testing
- `pytest -q` *(fails: OperationalError: connection failed)*
- `npm test` *(fails: missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_684f4f6bb7bc832a998d33a125787dd1