### PR TITLE
Add new filter state to SearchContext

### DIFF
--- a/frontend/src/shared/context/SearchContext.jsx
+++ b/frontend/src/shared/context/SearchContext.jsx
@@ -8,14 +8,21 @@ const SearchContext = createContext();
 export const useSearch = () => useContext(SearchContext); // ⬅️ Export useSearch hook here
 
 export function SearchProvider({ children }) {
-  const [filters, setFilters] = useState({
+  const initialFilters = {
+    person: "",
     selectedPersonId: null,
+    selectedFamilyId: null,
+    compareIds: [],
     yearRange: [1800, 2000],
-    eventTypes: [],
+    eventTypes: {},
     vague: false,
     relations: {},
-    sources: [],
-  });
+    sources: {},
+  };
+
+  const [filters, setFilters] = useState(initialFilters);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const clearAll = () => setFilters(initialFilters);
 
   const [mode, setMode] = useState('default');
 
@@ -32,7 +39,17 @@ export function SearchProvider({ children }) {
   }, [filters]);
 
   return (
-    <SearchContext.Provider value={{ filters, setFilters, mode, setMode }}>
+    <SearchContext.Provider
+      value={{
+        filters,
+        setFilters,
+        mode,
+        setMode,
+        isDrawerOpen,
+        setIsDrawerOpen,
+        clearAll,
+      }}
+    >
       {children}
     </SearchContext.Provider>
   );


### PR DESCRIPTION
## Summary
- expose extra filter state values via SearchContext

## Testing
- `pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684f4f5f29dc832abd86e05e81d98458

## Summary by Sourcery

Expand SearchContext to include additional filter parameters, drawer state management, and a clear-all action.

Enhancements:
- Extend filter state with `person`, `selectedFamilyId`, and `compareIds`, and convert `eventTypes` and `sources` to objects.
- Add `isDrawerOpen` state, expose `setIsDrawerOpen`, and introduce `clearAll` to reset filters.