### PR TITLE
Improve parser and upload validation

### DIFF
--- a/tests/routes/test_upload_enhancements.py
+++ b/tests/routes/test_upload_enhancements.py
@@ -1,0 +1,22 @@
+import tempfile
+from backend.models import UploadedTree
+
+def test_invalid_gedcom_extension_rejected(client, db_session):
+    bad_data = b"not a gedcom"
+    with tempfile.NamedTemporaryFile(suffix='.gedcom', delete=False) as tmp:
+        tmp.write(bad_data)
+        tmp.flush()
+        path = tmp.name
+    with open(path, 'rb') as fh:
+        resp = client.post(
+            '/api/upload/',
+            data={
+                'file': (fh, 'bad.gedcom'),
+                'tree_name': 'BadFile'
+            },
+            content_type='multipart/form-data'
+        )
+    assert resp.status_code == 400
+    # ensure nothing persisted
+    assert db_session.query(UploadedTree).count() == 0
+

--- a/tests/test_parser_enhancements.py
+++ b/tests/test_parser_enhancements.py
@@ -1,0 +1,50 @@
+import uuid
+from backend.services.parser import GEDCOMParser
+from backend.models import Event, Location
+
+class DummyLocSvc:
+    def __init__(self, status="ok"):
+        self.status = status
+    def resolve_location(self, **_kw):
+        class Out:
+            raw_name = "X"
+            normalized_name = "" if self.status != "ok" else "place_x"
+            latitude = None
+            longitude = None
+            confidence_score = 0.0
+            status = self.status
+            source = "dummy"
+        return Out()
+
+def create_tree(session):
+    from backend.models import UploadedTree, TreeVersion
+    ut = UploadedTree(id=uuid.uuid4(), tree_name="T")
+    session.add(ut); session.flush()
+    tv = TreeVersion(id=uuid.uuid4(), uploaded_tree_id=ut.id, version_number=1)
+    session.add(tv); session.commit()
+    return tv.id
+
+def test_duplicate_events_skipped(db_session):
+    tree_id = create_tree(db_session)
+    parser = GEDCOMParser("tests/data/test_family_events.ged", DummyLocSvc())
+    parser.parse_file()
+    parser.save_to_db(db_session, tree_id=tree_id)
+    count1 = db_session.query(Event).filter_by(tree_id=tree_id).count()
+    parser.save_to_db(db_session, tree_id=tree_id)
+    count2 = db_session.query(Event).filter_by(tree_id=tree_id).count()
+    assert count1 == count2
+
+def test_unresolved_location_skipped(db_session):
+    tree_id = create_tree(db_session)
+    parser = GEDCOMParser(file_path="", location_service=DummyLocSvc(status="unresolved"))
+    parser.data = {
+        "individuals": [],
+        "families": [],
+        "events": [{"event_type": "birth", "location": "Atlantis", "date": "1 JAN 1900"}]
+    }
+    parser.save_to_db(db_session, tree_id=tree_id)
+    # location should not be created
+    assert db_session.query(Location).count() == 0
+    evt = db_session.query(Event).first()
+    assert evt and evt.location_id is None
+


### PR DESCRIPTION
## Summary
- validate `.gedcom` files the same as `.ged`
- begin DB transaction in `upload_tree` and remove nested commit
- allow `tree_id` alias in `save_to_db`
- skip duplicates and unresolved locations while logging warnings
- add regression tests for GEDCOM validation and parser edge cases

## Testing
- `pytest -q` *(fails: connection to 127.0.0.1 port 5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_684f53505728832a943ea1a83e7cb6a0

## Summary by Sourcery

Improve GEDCOM upload process by extending file validation, streamlining transactions, and handling edge cases more robustly

New Features:
- Allow ".gedcom" files in upload validation alongside ".ged"
- Support `tree_id` alias for `uploaded_tree_id` for backward compatibility

Bug Fixes:
- Skip duplicate events instead of inserting them
- Omit events with unresolved or missing locations and log warnings

Enhancements:
- Use a single transaction context (`SessionLocal.begin`) and replace nested commits with flush
- Improve logging messages for processing steps and warnings for missing data

Tests:
- Add regression tests for duplicate event skipping, unresolved location handling, and invalid `.gedcom` extension rejection