### PR TITLE
Rewrite geocoding fallback logic

### DIFF
--- a/backend/services/geocode.py
+++ b/backend/services/geocode.py
@@ -85,7 +85,7 @@ class PermanentCacheGeocoder:
             confidence_score=float(conf or 0.0),
             confidence_label=src,
             status="ok",
-            source=src,
+            source="cache",
         )
 
 
@@ -169,6 +169,9 @@ class ExternalAPIGeocoder:
         self.api_key = api_key
 
     def resolve(self, geocode: "Geocode", session, place: str) -> Optional[LocationOut]:
+        if geocode.mock_mode:
+            logger.info("🛑 Mock mode active - skipping API call for '%s'", place)
+            return None
         result = geocode._google(place) or geocode._nominatim_geocode(place)
         if not result:
             return None
@@ -197,21 +200,24 @@ class Geocode:
         manual_fixes: Optional[Dict[str, Any]] = None,
         historical_lookup: Optional[Dict[str, Any]] = None,
         unresolved_logger=None,
+        mock_mode: bool | None = None,
     ) -> None:
         self.api_key = api_key
         self.cache_file = Path(cache_file or DEFAULT_CACHE_PATH)
         self.cache_enabled = use_cache
         self.cache: Dict[str, Any] = self._load_cache() if use_cache else {}
         self.unresolved_logger = unresolved_logger
+        self.mock_mode = bool(
+            os.getenv("MAPEM_MOCK_GEOCODE", "0") == "1" if mock_mode is None else mock_mode
+        )
 
         self.manual_fixes = manual_fixes or {}
         self.historical_lookup = historical_lookup or {}
 
         self.plugins = [
             ManualOverrideGeocoder(self.manual_fixes),
-            PermanentCacheGeocoder(),
             HistoricalGeocoder(self.historical_lookup),
-            FuzzyAliasGeocoder(),
+            PermanentCacheGeocoder(),
             ExternalAPIGeocoder(api_key),
         ]
 
@@ -324,7 +330,6 @@ __all__ = [
     "ManualOverrideGeocoder",
     "PermanentCacheGeocoder",
     "HistoricalGeocoder",
-    "FuzzyAliasGeocoder",
     "ExternalAPIGeocoder",
     "LocationOut",
 ]

--- a/backend/services/location_processor.py
+++ b/backend/services/location_processor.py
@@ -307,7 +307,7 @@ def process_location(
         latitude=None,
         longitude=None,
         confidence_score=0.0,
-        confidence_label="",
+        confidence_label="unresolved",
         status="unresolved",
         source="api",
         timestamp=now,

--- a/backend/services/location_processor.py
+++ b/backend/services/location_processor.py
@@ -188,14 +188,16 @@ def process_location(
     # 2. manual fixes
     if norm in MANUAL_FIXES:
         fix = MANUAL_FIXES[norm]
+        normalized_name = fix.get("normalized_name", norm)
         logger.info(
-            "🟧 fallback=manual status=manual raw='%s' year=%s src=manual",
+            "🟧 fallback=manual status=manual raw='%s' year=%s src=manual normalized='%s'",
             raw_place,
             event_year,
+            normalized_name,
         )
         return LocationOut(
             raw_name=fix.get("raw_name", raw_place),
-            normalized_name=fix.get("normalized_name", norm),
+            normalized_name=normalized_name,
             latitude=fix.get("lat") or fix.get("latitude"),
             longitude=fix.get("lng") or fix.get("longitude"),
             confidence_score=float(fix.get("confidence", 1.0)),

--- a/backend/services/location_processor.py
+++ b/backend/services/location_processor.py
@@ -210,11 +210,27 @@ def process_location(
     # alias + fuzzy cleanup removed for strict fallback ordering
 
     # 3. vague county or state fallback
-    if norm in COUNTY_VAGUE or norm in STATE_VAGUE:
-        if norm in COUNTY_VAGUE:
-            lat, lng = COUNTY_VAGUE[norm]
-        else:
-            lat, lng = STATE_VAGUE[norm]
+    if norm in COUNTY_VAGUE:
+        lat, lng = COUNTY_VAGUE[norm]
+        logger.info(
+            "🟦 fallback=vague status=vague raw='%s' year=%s src=vague",
+            raw_place,
+            event_year,
+        )
+        return LocationOut(
+            raw_name=raw_place,
+            normalized_name=norm,
+            latitude=lat,
+            longitude=lng,
+            confidence_score=0.3,
+            confidence_label="low",
+            status="vague",
+            source="vague",
+            timestamp=now,
+        )
+
+    elif norm in STATE_VAGUE:
+        lat, lng = STATE_VAGUE[norm]
         logger.info(
             "🟦 fallback=vague status=vague raw='%s' year=%s src=vague",
             raw_place,

--- a/backend/services/location_service.py
+++ b/backend/services/location_service.py
@@ -23,6 +23,7 @@ class LocationService:
         cache_file: Optional[str] = None,
         use_cache: bool = True,
         data_dir: Optional[Path] = None,
+        mock_mode: bool | None = None,
     ):
         # Set up base data dir (guaranteed Path object)
         self.data_dir = Path(
@@ -34,7 +35,10 @@ class LocationService:
 
         # Set up geocoder instance
         self.geocoder = Geocode(
-            api_key=api_key, cache_file=cache_file, use_cache=use_cache
+            api_key=api_key,
+            cache_file=cache_file,
+            use_cache=use_cache,
+            mock_mode=mock_mode,
         )
 
         # Manual fix and history support (future expansion)

--- a/tests/services/test_fallback_logic.py
+++ b/tests/services/test_fallback_logic.py
@@ -1,0 +1,84 @@
+import json
+import pytest
+from pathlib import Path
+
+from backend.services.location_service import LocationService
+from backend.models.location_models import LocationOut
+
+@pytest.fixture(autouse=True)
+def data_files(tmp_path: Path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "manual_place_fixes.json").write_text(json.dumps({
+        "manualtown_mt": {"lat": 1.0, "lng": 2.0}
+    }))
+    hist_dir = data_dir / "historical_places"
+    hist_dir.mkdir()
+    (hist_dir / "hist.json").write_text(json.dumps({
+        "oldplace_op": {"lat": 3.0, "lng": 4.0}
+    }))
+    monkeypatch.setenv("MAPEM_DATA_DIR", str(data_dir))
+    # update loaded tables
+    import backend.services.location_processor as lp
+    lp.MANUAL_FIXES = {"manualtown_mt": {"lat": 1.0, "lng": 2.0}}
+    lp.HISTORICAL_LOOKUP = {"oldplace_op": (3.0, 4.0, "oldplace_op")}
+
+@pytest.fixture
+def svc(monkeypatch):
+    class DummyGeo:
+        def get_or_create_location(self, _s, place):
+            if "lowtown" in place.lower():
+                return LocationOut(
+                    raw_name=place,
+                    normalized_name="lowtown_lt",
+                    latitude=5.0,
+                    longitude=6.0,
+                    confidence_score=0.3,
+                    confidence_label="api",
+                    status="ok",
+                    source="api",
+                )
+            return None
+    monkeypatch.setattr("backend.services.location_service.Geocode", lambda *a, **k: DummyGeo())
+    return LocationService(mock_mode=True)
+
+
+def test_manual_hit(svc):
+    out = svc.resolve_location("ManualTown, MT", event_year=1900)
+    assert out.status == "manual"
+    assert out.source == "manual"
+
+
+def test_historical_hit(svc):
+    out = svc.resolve_location("OldPlace, OP", event_year=1800)
+    assert out.status == "historical"
+
+
+def test_vague_input(svc):
+    out = svc.resolve_location("Mississippi", event_year=1950)
+    assert out.status == "vague"
+    assert out.confidence_label == "low"
+
+
+def test_unresolved_case(svc):
+    out = svc.resolve_location("Unknownville", event_year=2000)
+    assert out.status == "unresolved"
+
+
+def test_low_confidence_api_hit(svc):
+    out = svc.resolve_location("LowTown, LT", event_year=2000)
+    assert out.source == "api"
+    assert out.confidence_score == 0.3
+
+
+def test_mock_mode(svc, monkeypatch):
+    called = {}
+    class BoomGeo:
+        def get_or_create_location(self, *_a, **_k):
+            called['hit'] = True
+            return None
+    monkeypatch.setattr("backend.services.location_service.Geocode", lambda *a, **k: BoomGeo())
+    local = LocationService(mock_mode=True)
+    local.resolve_location("NoApiTown")
+    assert called.get('hit') is None
+


### PR DESCRIPTION
## Summary
- adjust geocode plugin order and add mock mode
- rework location processor fallback order and logging
- support mock mode in location service
- add fallback test stubs

## Testing
- `pytest tests/services/test_fallback_logic.py -q`
- `pytest -q` *(fails: sqlalchemy connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_684fab72c25c832abc11b9b712484c96

## Summary by Sourcery

Rewrite and streamline the geocoding fallback logic in location processing, enforce a strict fallback order with unified logging and adjusted confidence labels, and add mock mode support for tests.

New Features:
- Add mock geocoding mode to skip external API calls in LocationService and Geocode.

Enhancements:
- Remove fuzzy-alias and RapidFuzz matching to simplify fallback sequence.
- Combine county and state fallbacks into a single vague step with unified logging and reduced confidence.
- Adjust confidence scores and labels for historical and API-derived results.
- Refactor logging for all fallback steps to use structured keys (fallback, status, raw, year, src).
- Reorder geocode plugins to manual override, historical, cache, then external API.

Tests:
- Add pytest tests to verify manual fix, historical, vague, unresolved, low-confidence API, and mock mode behaviors.