### PR TITLE
Refactor upload flow and add async GEDCOM processing

### DIFF
--- a/backend/services/upload_service.py
+++ b/backend/services/upload_service.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Tuple
+
+from werkzeug.datastructures import FileStorage
+
+from backend.utils.helpers import generate_temp_path
+from backend.utils.logger import get_file_logger
+
+logger = get_file_logger("upload_service")
+
+# Constants duplicated in upload route for shared config
+MAX_FILE_SIZE_MB = 20
+ALLOWED_EXTENSIONS = {".ged", ".gedcom"}
+
+
+def is_valid_gedcom_content(file: FileStorage) -> bool:
+    """Basic GEDCOM sanity check: look for HEAD and TRLR records."""
+    try:
+        file.seek(0)
+        start = file.read(1024).decode(errors="ignore")
+        file.seek(-1024, os.SEEK_END)
+        end = file.read(1024).decode(errors="ignore")
+    except Exception:
+        file.seek(0)
+        return False
+    finally:
+        file.seek(0)
+    return "0 HEAD" in start and "0 TRLR" in end
+
+
+def validate_upload(file: FileStorage) -> Tuple[bool, str, float]:
+    """Return (ok, message, size_mb)."""
+    if not file or not file.filename:
+        return False, "Missing file", 0.0
+
+    file.seek(0, os.SEEK_END)
+    size_bytes = file.tell()
+    size_mb = size_bytes / (1024 * 1024)
+    file.seek(0)
+
+    if size_mb > MAX_FILE_SIZE_MB:
+        return False, f"File > {MAX_FILE_SIZE_MB} MB", size_mb
+
+    ext = Path(file.filename).suffix.lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        return False, "Invalid file type", size_mb
+
+    if not is_valid_gedcom_content(file):
+        return False, "File content is not a valid GEDCOM file", size_mb
+
+    return True, "", size_mb
+
+
+def save_file(file: FileStorage, temp_dir: str = "/tmp") -> str:
+    """Persist upload to a temporary file path and return the path."""
+    tmp_name = generate_temp_path(Path(file.filename).suffix)
+    path = str(Path(temp_dir) / tmp_name)
+    file.seek(0)
+    file.save(path)
+    logger.debug("Saved uploaded file to %s", path)
+    return path

--- a/backend/tasks/upload_tasks.py
+++ b/backend/tasks/upload_tasks.py
@@ -1,0 +1,38 @@
+import logging
+import os
+from pathlib import Path
+
+from backend.celery_app import celery_app
+from backend.db import SessionLocal
+from backend.models import TreeVersion, UploadedTree
+from backend.services.location_service import LocationService
+from backend.services.parser import GEDCOMParser
+
+logger = logging.getLogger("mapem.upload_tasks")
+
+@celery_app.task(bind=True, max_retries=3, default_retry_delay=10)
+def process_gedcom_task(self, file_path: str, tree_name: str, uploaded_tree_id: str):
+    """Background GEDCOM processing."""
+    logger.info("📂 [Task] Starting parse for %s", file_path)
+    with SessionLocal.begin() as session:
+        try:
+            loc = LocationService(api_key=os.getenv("GEOCODE_API_KEY") or "DUMMY_KEY")
+            parser = GEDCOMParser(file_path, loc)
+            parsed = parser.parse_file()
+            logger.info("📑 [Task] Parsed %d individuals, %d events", len(parsed["individuals"]), len(parsed["events"]))
+
+            version = TreeVersion(uploaded_tree_id=uploaded_tree_id, version_number=1)
+            session.add(version)
+            session.flush()
+            summary = parser.save_to_db(session, uploaded_tree_id=uploaded_tree_id, tree_version_id=version.id)
+            logger.info("✅ [Task] Saved tree %s version %s", uploaded_tree_id, version.id)
+        except Exception as exc:
+            logger.exception("❌ [Task] Failed processing tree %s: %s", uploaded_tree_id, exc)
+            raise self.retry(exc=exc)
+        finally:
+            if os.path.exists(file_path):
+                try:
+                    Path(file_path).unlink()
+                except OSError:
+                    logger.warning("⚠️ Could not remove temp file %s", file_path)
+    return summary


### PR DESCRIPTION
## Summary
- add `upload_service` utilities for file validation and temp save
- create Celery task for async GEDCOM processing
- refactor upload route to use new service and queue large files
- improve logging and duplicate tree checks

## Testing
- `pytest -q` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6850a3b94968832a86125b13804c2946

## Summary by Sourcery

Refactor the GEDCOM upload endpoint to delegate validation and temp storage to a new service, add a size threshold to queue large uploads via Celery, and enhance logging and duplicate name checks.

New Features:
- Add Celery-based asynchronous GEDCOM processing for large file uploads
- Introduce upload_service module for centralized file validation and temporary storage

Bug Fixes:
- Prevent duplicate tree names by validating against existing entries in both sync and async flows

Enhancements:
- Refactor upload endpoint to use upload_service and route based on file size
- Improve logging throughout the upload flow
- Extract validation logic from the route and consolidate into a shared utility