### PR TITLE
Enhance model relationships and validation

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,4 +1,5 @@
 # backend/models/__init__.py
+"""Convenient access to all SQLAlchemy models used by the application."""
 
 from .base            import Base
 from .uploaded_tree   import UploadedTree, TreePerson, TreeRelationship
@@ -19,8 +20,30 @@ import logging
 from backend.db import engine
 
 
+def verify_models():
+    """Quick sanity check ensuring expected columns exist."""
+    expected = {
+        "locations": {"status", "source", "confidence_score"},
+        "individuals": {"tree_id"},
+    }
+    mismatches = {}
+    for table_name, expected_cols in expected.items():
+        table = Base.metadata.tables.get(table_name)
+        if not table:
+            continue
+        cols = {c.name for c in table.columns}
+        missing = expected_cols - cols
+        if missing:
+            mismatches[table_name] = missing
+    if mismatches:
+        logging.warning("Model verification mismatches: %s", mismatches)
+    else:
+        logging.debug("All expected columns present")
+
+
 if __name__ == "__main__":
     from pprint import pprint
 
     print("📦 Tables in Base.metadata:")
     pprint(list(Base.metadata.tables))
+    verify_models()

--- a/backend/models/event.py
+++ b/backend/models/event.py
@@ -1,4 +1,5 @@
 # backend/models/event.py
+"""Event records such as births, deaths or marriages."""
 import logging
 import uuid
 from sqlalchemy import (
@@ -56,7 +57,7 @@ class Event(Base, ReprMixin):
 
     # ─── Relationships ───────────────────────────────────
     tree           = relationship("TreeVersion", back_populates="events", lazy="joined")
-    location       = relationship("Location", lazy="joined")
+    location       = relationship("Location", back_populates="events", lazy="joined")
     event_sources  = relationship("EventSource", back_populates="event", cascade="all, delete-orphan", lazy="noload")
 
     participants   = relationship(
@@ -80,3 +81,4 @@ class Event(Base, ReprMixin):
         }
         logger.debug("Event.serialize → %s", data)
         return data
+

--- a/backend/models/individual.py
+++ b/backend/models/individual.py
@@ -1,6 +1,8 @@
 import logging
 import uuid
 
+"""Individuals parsed from GEDCOM files with optional residences."""
+
 from sqlalchemy import (
     Column,
     String,
@@ -117,6 +119,11 @@ class ResidenceHistory(Base, TimestampMixin, ReprMixin):
         back_populates="residences",
         lazy="noload",
     )
+    location = relationship(
+        "Location",
+        back_populates="residences",
+        lazy="joined",
+    )
 
     def __str__(self):
         return f"{self.start_date or '?'} to {self.end_date or '?'} @ loc:{self.location_id}"
@@ -126,3 +133,5 @@ class ResidenceHistory(Base, TimestampMixin, ReprMixin):
 
     def __repr__(self):
         return f"<ResidenceHistory id={self.id} individual_id={self.individual_id} notes={self.notes}>"
+
+

--- a/backend/models/location_version.py
+++ b/backend/models/location_version.py
@@ -1,4 +1,5 @@
 # backend/models/location_version.py
+"""Time-bounded alternative coordinates for a location."""
 from sqlalchemy import (
     Column,
     Float,
@@ -10,13 +11,14 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.sql import func
 from backend.models.base import Base  # ✅ fixed import
+from sqlalchemy.orm import relationship
 import uuid
 
 class LocationVersion(Base):
     __tablename__ = "location_versions"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    location_id = Column(UUID(as_uuid=True), ForeignKey("locations.id"), nullable=False)
+    location_id = Column(UUID(as_uuid=True), ForeignKey("locations.id", ondelete="CASCADE"), nullable=False, index=True)
 
     lat = Column(Float, nullable=False)
     lng = Column(Float, nullable=False)
@@ -29,3 +31,10 @@ class LocationVersion(Base):
     notes  = Column(JSONB)
 
     created_at = Column(DateTime, server_default=func.now())
+
+    location = relationship(
+        "Location",
+        back_populates="versions",
+        lazy="joined",
+    )
+


### PR DESCRIPTION
## Summary
- index `normalized_name` and validate coordinates in `Location`
- add cascade-aware backrefs for events, residences and location versions
- clarify relationships in `Event` and `ResidenceHistory`
- wire up location versions model and add verification helper

## Testing
- `pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6850a3ccec8c832a98fd5454860b3933

## Summary by Sourcery

Enhance model schema and relationships by adding indexes, validators, and cascade-aware backrefs, and introduce a runtime verification helper for model integrity.

Enhancements:
- Add cascade-aware back_populates relationships between Location and Event, ResidenceHistory, and LocationVersion models
- Add index on Location.normalized_name and enforce cascade delete on related LocationVersion entries
- Implement attribute validators to enforce valid latitude and longitude ranges
- Clarify and unify relationship loading strategies for ResidenceHistory and Event models
- Introduce a verify_models helper to log missing expected columns at runtime