### PR TITLE
Add logger to event_helpers module

### DIFF
--- a/backend/utils/event_helpers.py
+++ b/backend/utils/event_helpers.py
@@ -2,7 +2,7 @@ import logging
 from typing import Tuple
 from backend.models import Event
 
- 
+logger = logging.getLogger(__name__)
 
 def primary_participant(event: Event, *, strategy: str = "first") -> Tuple[int, str]:
     """


### PR DESCRIPTION
## Summary
- define `logger = logging.getLogger(__name__)` in `event_helpers`

## Testing
- `pytest -q` *(fails: OperationalError because database isn't running)*

------
https://chatgpt.com/codex/tasks/task_e_6851e0069e0c832abd84f0d859069794