### PR TITLE
Fix geocode test assertions

### DIFF
--- a/tests/features/test_basic_api.py
+++ b/tests/features/test_basic_api.py
@@ -6,8 +6,8 @@ def test_geocode_single_location():
     """✅ Test Geocode().get_or_create_location() directly."""
     geocoder = Geocode()
     result = geocoder.get_or_create_location(None, "Chicago, Illinois, USA")
-    assert result.get("latitude") is not None
-    assert result.get("longitude") is not None
+    assert result.latitude is not None
+    assert result.longitude is not None
     assert "confidence_label" in result
     assert "confidence_score" in result
 


### PR DESCRIPTION
## Summary
- use attribute access for latitude and longitude in geocode tests

## Testing
- `pytest -q` *(fails: connection refused to Postgres DB)*

------
https://chatgpt.com/codex/tasks/task_e_6851e00a1cac832a8ad27a2fb2998c3e

## Summary by Sourcery

Tests:
- Replace result.get("latitude") and result.get("longitude") calls with direct attribute access in geocode tests