### PR TITLE
Fix manual fixes test loading

### DIFF
--- a/tests/scripts/test_fix_and_retry.py
+++ b/tests/scripts/test_fix_and_retry.py
@@ -1,7 +1,7 @@
 import json
 import tempfile
 from pathlib import Path
-from backend.services.geocode import Geocode
+from backend.services.geocode import Geocode, LocationOut
 from backend.utils.helpers import normalize_location
 
 
@@ -57,13 +57,14 @@ def test_apply_manual_fixes_on_mock_data(tmp_path):
     geo = Geocode(use_cache=False, manual_fixes=fixes)
     geo.cache_file = str(tmp_path / "test_cache.json")
 
-    # Inject the test fix
-    from backend.services.location_processor import load_manual_place_fixes
-    manual_fixes = load_manual_place_fixes(path=manual_fixes_path)
+    # Inject the test fix via JSON loading
+    with open(manual_fixes_path, encoding="utf-8") as f:
+        manual_fixes = json.load(f)
 
     norm_name = normalize_location("Ackerman, Choctaw, Mississippi, USA")
     assert norm_name in manual_fixes
 
     result = geo.get_or_create_location(None, "Ackerman, Choctaw, Mississippi, USA")
-    assert result["confidence_label"] == "manual"
-    assert result["latitude"] == 33.3037
+    assert isinstance(result, LocationOut)
+    assert result.confidence_label == "manual"
+    assert result.latitude == 33.3037


### PR DESCRIPTION
## Summary
- load `manual_place_fixes.json` directly in `test_fix_and_retry`
- assert returned object has manual confidence

## Testing
- `pytest -q tests/scripts/test_fix_and_retry.py::test_apply_manual_fixes_on_mock_data -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e01205dc832aa09de4cbed4e4888

## Summary by Sourcery

Refactor test_apply_manual_fixes_on_mock_data to load manual fixes JSON directly and adjust result assertions

Enhancements:
- Load manual fixes via json.load instead of the service loader in the test

Tests:
- Assert get_or_create_location returns a LocationOut instance and update confidence_label and latitude assertions to use attributes