### PR TITLE
Add skip for DB snapshot tests

### DIFF
--- a/tests/db/test_event_counts.py
+++ b/tests/db/test_event_counts.py
@@ -1,6 +1,19 @@
+"""Database snapshot tests.
+
+These tests require a pre-populated database snapshot and will be skipped
+unless the environment variable ``RUN_DB_SNAPSHOTS`` is set to ``1``.
+"""
+
+import os
 import pytest
 from sqlalchemy import text
 from backend.db import SessionLocal
+
+if os.environ.get("RUN_DB_SNAPSHOTS") != "1":
+    pytest.skip(
+        "Skipping DB snapshot tests; set RUN_DB_SNAPSHOTS=1 to run",
+        allow_module_level=True,
+    )
 
 @pytest.mark.db
 def test_event_type_distribution_snapshot():

--- a/tests/db/test_event_geolocation.py
+++ b/tests/db/test_event_geolocation.py
@@ -1,6 +1,19 @@
+"""Database snapshot tests.
+
+These tests require a pre-populated database snapshot and will be skipped
+unless the environment variable ``RUN_DB_SNAPSHOTS`` is set to ``1``.
+"""
+
+import os
 import pytest
 from sqlalchemy import text
 from backend.db import SessionLocal
+
+if os.environ.get("RUN_DB_SNAPSHOTS") != "1":
+    pytest.skip(
+        "Skipping DB snapshot tests; set RUN_DB_SNAPSHOTS=1 to run",
+        allow_module_level=True,
+    )
 
 @pytest.mark.db
 def test_geolocated_events_have_coordinates():

--- a/tests/db/test_event_integrity.py
+++ b/tests/db/test_event_integrity.py
@@ -1,6 +1,19 @@
+"""Database snapshot tests.
+
+These tests require a pre-populated database snapshot and will be skipped
+unless the environment variable ``RUN_DB_SNAPSHOTS`` is set to ``1``.
+"""
+
+import os
 import pytest
 from sqlalchemy import text
 from backend.db import SessionLocal
+
+if os.environ.get("RUN_DB_SNAPSHOTS") != "1":
+    pytest.skip(
+        "Skipping DB snapshot tests; set RUN_DB_SNAPSHOTS=1 to run",
+        allow_module_level=True,
+    )
 
 TREE_ID = "ae81ce29-d64f-4600-b21c-21f93c008df3"
 


### PR DESCRIPTION
## Summary
- ensure DB snapshot tests are skipped unless RUN_DB_SNAPSHOTS=1

## Testing
- `pytest tests/db -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e016ed30832a9954b5e794525045