### PR TITLE
Clean up test output

### DIFF
--- a/tests/db/test_event_counts.py
+++ b/tests/db/test_event_counts.py
@@ -12,9 +12,6 @@ def test_event_type_distribution_snapshot():
         )
         counts = dict(result.all())
 
-        print("\n📊 Event Type Distribution:")
-        for k, v in counts.items():
-            print(f"  {k:10} → {v}")
 
         expected = {
             "birth": 643,

--- a/tests/db/test_event_geolocation.py
+++ b/tests/db/test_event_geolocation.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from sqlalchemy import text
 from backend.db import SessionLocal
@@ -41,16 +42,17 @@ def test_geolocated_events_have_coordinates():
 
         vague = [r for r in rows if r.status in ("vague", "vague_state_pre1890")]
 
-        # ── Step 3: Output ──
-        print(f"\n📍 Tree ID: {tree_id}")
-        print(f"📦 Total Events: {total_events}")
-        print(f"🚨 Missing Coordinates: {len(missing_coords)}")
-        print(f"🕳️ Vague Locations: {len(vague)}")
+        # ── Step 3: Output (use logging to aid debugging if needed) ──
+        logger = logging.getLogger(__name__)
+        logger.info("Tree ID: %s", tree_id)
+        logger.info("Total Events: %s", total_events)
+        logger.info("Missing Coordinates: %s", len(missing_coords))
+        logger.info("Vague Locations: %s", len(vague))
 
         if missing_coords:
-            print("\n⚠️ Events missing lat/lng (top 10 shown):")
+            logger.info("Events missing lat/lng (top 10 shown):")
             for r in missing_coords[:10]:
-                print(f" - ID: {r['event_id']}, type: {r['event_type']}, place: '{r['place']}', status: {r['status']}")
+                logger.info(" - ID: %s, type: %s, place: '%s', status: %s", r['event_id'], r['event_type'], r['place'], r['status'])
 
         # ── Step 4: Assertions ──
         assert total_events > 0, "No events found for the latest tree"

--- a/tests/db/test_event_integrity.py
+++ b/tests/db/test_event_integrity.py
@@ -21,9 +21,6 @@ def test_event_type_distribution_snapshot():
         )
         counts = dict(result.all())
 
-        print("\n📊 Event Type Distribution:")
-        for k, v in counts.items():
-            print(f"  {k:10} → {v}")
 
         expected = {
             "birth": 99,
@@ -52,7 +49,6 @@ def test_total_event_count_matches_expected():
             {"tree_id": TREE_ID}
         )
         total = result.scalar()
-        print(f"\n🧮 Total event count for tree {TREE_ID}: {total}")
         assert total == 221, f"Expected 221 events, got {total}"
 
     finally:
@@ -73,7 +69,6 @@ def test_event_types_are_valid():
         found = {row[0] for row in result.fetchall()}
         allowed = {"birth", "death", "marriage", "residence", "burial", "census", "christening"}
 
-        print(f"\n✅ Event types used: {found}")
         assert found.issubset(allowed), f"Invalid event types detected: {found - allowed}"
 
     finally:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,7 +23,6 @@ def dummy_location_service():
 
 GEDCOM_TEST_FILE = "tests/data/test_family_events.ged"
 
-print("GEDCOMParser method list:", dir(GEDCOMParser))
 
 from datetime import datetime, timezone
 
@@ -97,10 +96,3 @@ def test_missing_event_type_is_skipped(db_session, dummy_location_service):
     summary = parser.save_to_db(db_session, tree_id=tree_id)
     assert summary["event_count"] == 0
     assert any("Missing event_type" in w for w in summary["warnings"])
-print("✅ parser.py LOADED")
-
-from importlib import reload
-import backend.services.parser as parser_mod
-reload(parser_mod)
-from backend.services.parser import GEDCOMParser
-print("✅ after reload:", "save_to_db" in dir(GEDCOMParser))

--- a/tests/test_regression_endpoints.py
+++ b/tests/test_regression_endpoints.py
@@ -38,7 +38,12 @@ def tree_ids():
 def timed_get(client, url):
     start = time.time()
     res = client.get(url)
-    print(f"{url} -> {res.status_code} in {round(time.time() - start,2)} s")
+    logging.getLogger(__name__).info(
+        "%s -> %s in %.2f s",
+        url,
+        res.status_code,
+        round(time.time() - start, 2),
+    )
     return res
 
 


### PR DESCRIPTION
## Summary
- remove print statements and reload code from `tests/test_parser.py`
- drop debug prints from database tests
- log request timing in `test_regression_endpoints` rather than printing

## Testing
- `pytest -q` *(fails: connection refused for PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6851e02a7a40832aab70ec2293265f0f

## Summary by Sourcery

Clean up test output and streamline test code by removing ad-hoc print debug statements and obsolete reload calls, replacing them with structured logger.info calls where appropriate.

Tests:
- Convert print-based debug output in database and regression endpoint tests to logger.info calls and drop related print loops
- Remove redundant print statements and module reload code from parser tests to simplify test setup