### PR TITLE
Add latest TreeVersion fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # test/conftest.py
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 from backend.main import create_app
@@ -66,3 +66,15 @@ def dummy_location_service():
                 source            = "test"
             return Out()
     return Dummy()
+
+
+@pytest.fixture
+def latest_tree_version_id(db_session):
+    """Return the most recently created TreeVersion ID from the test DB."""
+    row = db_session.execute(
+        text(
+            "SELECT id FROM tree_versions ORDER BY created_at DESC LIMIT 1"
+        )
+    ).fetchone()
+    assert row is not None, "No tree_versions found in test DB"
+    return row[0]

--- a/tests/db/test_event_integrity.py
+++ b/tests/db/test_event_integrity.py
@@ -2,22 +2,20 @@ import pytest
 from sqlalchemy import text
 from backend.db import SessionLocal
 
-TREE_ID = "ae81ce29-d64f-4600-b21c-21f93c008df3"
-
 @pytest.mark.db
-def test_event_type_distribution_snapshot():
+def test_event_type_distribution_snapshot(latest_tree_version_id):
     """Snapshot check of event_type counts for Tree ID."""
     session = SessionLocal()
     try:
         result = session.execute(
             text("""
-                SELECT event_type, COUNT(*) 
-                FROM events 
-                WHERE tree_id = :tree_id 
-                GROUP BY event_type 
+                SELECT event_type, COUNT(*)
+                FROM events
+                WHERE tree_id = :tree_id
+                GROUP BY event_type
                 ORDER BY event_type
             """),
-            {"tree_id": TREE_ID}
+            {"tree_id": latest_tree_version_id}
         )
         counts = dict(result.all())
 
@@ -41,7 +39,7 @@ def test_event_type_distribution_snapshot():
 
 
 @pytest.mark.db
-def test_total_event_count_matches_expected():
+def test_total_event_count_matches_expected(latest_tree_version_id):
     """Verify total number of events for the tree matches upload summary."""
     session = SessionLocal()
     try:
@@ -49,10 +47,10 @@ def test_total_event_count_matches_expected():
             text("""
                 SELECT COUNT(*) FROM events WHERE tree_id = :tree_id
             """),
-            {"tree_id": TREE_ID}
+            {"tree_id": latest_tree_version_id}
         )
         total = result.scalar()
-        print(f"\n🧮 Total event count for tree {TREE_ID}: {total}")
+        print(f"\n🧮 Total event count for tree {latest_tree_version_id}: {total}")
         assert total == 221, f"Expected 221 events, got {total}"
 
     finally:
@@ -60,7 +58,7 @@ def test_total_event_count_matches_expected():
 
 
 @pytest.mark.db
-def test_event_types_are_valid():
+def test_event_types_are_valid(latest_tree_version_id):
     """Ensure all event types used are from known list."""
     session = SessionLocal()
     try:
@@ -68,7 +66,7 @@ def test_event_types_are_valid():
             text("""
                 SELECT DISTINCT event_type FROM events WHERE tree_id = :tree_id
             """),
-            {"tree_id": TREE_ID}
+            {"tree_id": latest_tree_version_id}
         )
         found = {row[0] for row in result.fetchall()}
         allowed = {"birth", "death", "marriage", "residence", "burial", "census", "christening"}


### PR DESCRIPTION
## Summary
- add `latest_tree_version_id` fixture that queries the test DB
- use this fixture in event integrity tests

## Testing
- `pytest tests/db/test_event_integrity.py -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6851e02ad41c832a95c595e900bc2d7a

## Summary by Sourcery

Add a pytest fixture to fetch the latest TreeVersion ID and update event integrity tests to use it

New Features:
- Introduce `latest_tree_version_id` fixture to query the test DB for the most recent TreeVersion ID

Enhancements:
- Refactor event integrity tests to replace hardcoded TREE_ID with the dynamic `latest_tree_version_id` fixture

Tests:
- Update SQL queries and assertions in event integrity tests to leverage the new fixture and remove the static TREE_ID constant